### PR TITLE
Fix: annotations for serviceAccount are rendered as labels

### DIFF
--- a/charts/risingwave/templates/serviceaccount.yaml
+++ b/charts/risingwave/templates/serviceaccount.yaml
@@ -10,12 +10,14 @@ metadata:
   name: {{ include "risingwave.serviceAccountName" . }}
   labels:
     {{- include "risingwave.labels" . | nindent 4 }}
-  {{- $annotations := (include "risingwave.annotations" . ) | trim }}
-  {{- if $annotations }}
+  {{- if or (include "risingwave.annotations" .) .Values.serviceAccount.annotations }}
   annotations:
+    {{- $annotations := (include "risingwave.annotations" . ) | trim }}
+    {{- if $annotations }}
     {{ nindent 4 $annotations }}
-  {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR fixes serviceAccount annotations as describe in https://github.com/risingwavelabs/helm-charts/issues/2

closes https://github.com/risingwavelabs/helm-charts/issues/2