### PR TITLE
feat: add PodMonitor to operator's chart, make proxy optional

### DIFF
--- a/charts/risingwave-operator/Chart.yaml
+++ b/charts/risingwave-operator/Chart.yaml
@@ -7,13 +7,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.5.6"
+appVersion: "v0.5.7"
 
 home: https://www.risingwave.com
 icon: https://avatars.githubusercontent.com/u/77175557?s=48&v=4
@@ -24,6 +24,13 @@ keywords:
 - cloud-native
 - real-time
 - operator
+
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - bitnami-common
+  version: 2.x.x
 
 maintainers:
 - name: RisingWave Labs

--- a/charts/risingwave-operator/crds/risingwave-operator.crds.yaml
+++ b/charts/risingwave-operator/crds/risingwave-operator.crds.yaml
@@ -601,6 +601,19 @@ spec:
                                                     required:
                                                     - port
                                                     type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
                                                       is NOT supported as a LifecycleHandler
@@ -731,6 +744,19 @@ spec:
                                                         type: string
                                                     required:
                                                     - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
                                                     type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
@@ -2218,7 +2244,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -2291,6 +2319,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -2450,7 +2539,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -2518,6 +2609,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -2668,7 +2814,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -2741,6 +2889,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -2900,7 +3109,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -2968,6 +3179,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -5142,42 +5408,6 @@ spec:
                                                           status field of the claim.
                                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                         properties:
-                                                          claims:
-                                                            description: "Claims lists
-                                                              the names of resources,
-                                                              defined in spec.resourceClaims,
-                                                              that are used by this
-                                                              container. \n This is
-                                                              an alpha field and requires
-                                                              enabling the DynamicResourceAllocation
-                                                              feature gate. \n This
-                                                              field is immutable.
-                                                              It can only be set for
-                                                              containers."
-                                                            items:
-                                                              description: ResourceClaim
-                                                                references one entry
-                                                                in PodSpec.ResourceClaims.
-                                                              properties:
-                                                                name:
-                                                                  description: Name
-                                                                    must match the
-                                                                    name of one entry
-                                                                    in pod.spec.resourceClaims
-                                                                    of the Pod where
-                                                                    this field is
-                                                                    used. It makes
-                                                                    that resource
-                                                                    available inside
-                                                                    a container.
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                            type: array
-                                                            x-kubernetes-list-map-keys:
-                                                            - name
-                                                            x-kubernetes-list-type: map
                                                           limits:
                                                             additionalProperties:
                                                               anyOf:
@@ -5292,6 +5522,41 @@ spec:
                                                           is the name of the StorageClass
                                                           required by the claim. More
                                                           info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        description: 'volumeAttributesClassName
+                                                          may be used to set the VolumeAttributesClass
+                                                          used by this claim. If specified,
+                                                          the CSI driver will create
+                                                          or update the volume with
+                                                          the attributes defined in
+                                                          the corresponding VolumeAttributesClass.
+                                                          This has a different purpose
+                                                          than storageClassName, it
+                                                          can be changed after the
+                                                          claim is created. An empty
+                                                          string value means that
+                                                          no VolumeAttributesClass
+                                                          will be applied to the claim
+                                                          but it''s not allowed to
+                                                          reset this field to empty
+                                                          string once it is set. If
+                                                          unspecified and the PersistentVolumeClaim
+                                                          is unbound, the default
+                                                          VolumeAttributesClass will
+                                                          be set by the persistentvolume
+                                                          controller if it exists.
+                                                          If the resource referred
+                                                          to by volumeAttributesClass
+                                                          does not exist, this PersistentVolumeClaim
+                                                          will be set to a Pending
+                                                          state, as reflected by the
+                                                          modifyVolumeStatus field,
+                                                          until such as a resource
+                                                          exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                          (Alpha) Using this field
+                                                          requires the VolumeAttributesClass
+                                                          feature gate to be enabled.'
                                                         type: string
                                                       volumeMode:
                                                         description: volumeMode defines
@@ -5764,6 +6029,153 @@ spec:
                                                     be projected along with other
                                                     supported volume types
                                                   properties:
+                                                    clusterTrustBundle:
+                                                      description: "ClusterTrustBundle
+                                                        allows a pod to access the
+                                                        `.spec.trustBundle` field
+                                                        of ClusterTrustBundle objects
+                                                        in an auto-updating file.
+                                                        \n Alpha, gated by the ClusterTrustBundleProjection
+                                                        feature gate. \n ClusterTrustBundle
+                                                        objects can either be selected
+                                                        by name, or by the combination
+                                                        of signer name and a label
+                                                        selector. \n Kubelet performs
+                                                        aggressive normalization of
+                                                        the PEM contents written into
+                                                        the pod filesystem.  Esoteric
+                                                        PEM features such as inter-block
+                                                        comments and block headers
+                                                        are stripped.  Certificates
+                                                        are deduplicated. The ordering
+                                                        of certificates within the
+                                                        file is arbitrary, and Kubelet
+                                                        may change the order over
+                                                        time."
+                                                      properties:
+                                                        labelSelector:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this label selector.  Only
+                                                            has effect if signerName
+                                                            is set.  Mutually-exclusive
+                                                            with name.  If unset,
+                                                            interpreted as "match
+                                                            nothing".  If set but
+                                                            empty, interpreted as
+                                                            "match everything".
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          description: Select a single
+                                                            ClusterTrustBundle by
+                                                            object name.  Mutually-exclusive
+                                                            with signerName and labelSelector.
+                                                          type: string
+                                                        optional:
+                                                          description: If true, don't
+                                                            block pod startup if the
+                                                            referenced ClusterTrustBundle(s)
+                                                            aren't available.  If
+                                                            using name, then the named
+                                                            ClusterTrustBundle is
+                                                            allowed not to exist.  If
+                                                            using signerName, then
+                                                            the combination of signerName
+                                                            and labelSelector is allowed
+                                                            to match zero ClusterTrustBundles.
+                                                          type: boolean
+                                                        path:
+                                                          description: Relative path
+                                                            from the volume root to
+                                                            write the bundle.
+                                                          type: string
+                                                        signerName:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this signer name.
+                                                            Mutually-exclusive with
+                                                            name.  The contents of
+                                                            all selected ClusterTrustBundles
+                                                            will be unified and deduplicated.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
                                                     configMap:
                                                       description: configMap information
                                                         about the configMap data to
@@ -6761,32 +7173,6 @@ spec:
                                           than capacity recorded in the status field
                                           of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         properties:
-                                          claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
-                                            items:
-                                              description: ResourceClaim references
-                                                one entry in PodSpec.ResourceClaims.
-                                              properties:
-                                                name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
-                                                    inside a container.
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                            - name
-                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -6871,6 +7257,30 @@ spec:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: 'volumeAttributesClassName may
+                                          be used to set the VolumeAttributesClass
+                                          used by this claim. If specified, the CSI
+                                          driver will create or update the volume
+                                          with the attributes defined in the corresponding
+                                          VolumeAttributesClass. This has a different
+                                          purpose than storageClassName, it can be
+                                          changed after the claim is created. An empty
+                                          string value means that no VolumeAttributesClass
+                                          will be applied to the claim but it''s not
+                                          allowed to reset this field to empty string
+                                          once it is set. If unspecified and the PersistentVolumeClaim
+                                          is unbound, the default VolumeAttributesClass
+                                          will be set by the persistentvolume controller
+                                          if it exists. If the resource referred to
+                                          by volumeAttributesClass does not exist,
+                                          this PersistentVolumeClaim will be set to
+                                          a Pending state, as reflected by the modifyVolumeStatus
+                                          field, until such as a resource exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                          (Alpha) Using this field requires the VolumeAttributesClass
+                                          feature gate to be enabled.'
                                         type: string
                                       volumeMode:
                                         description: volumeMode defines what type
@@ -7415,6 +7825,19 @@ spec:
                                                     required:
                                                     - port
                                                     type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
                                                       is NOT supported as a LifecycleHandler
@@ -7545,6 +7968,19 @@ spec:
                                                         type: string
                                                     required:
                                                     - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
                                                     type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
@@ -9032,7 +9468,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -9105,6 +9543,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -9264,7 +9763,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -9332,6 +9833,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -9482,7 +10038,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -9555,6 +10113,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -9714,7 +10333,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -9782,6 +10403,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -11956,42 +12632,6 @@ spec:
                                                           status field of the claim.
                                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                         properties:
-                                                          claims:
-                                                            description: "Claims lists
-                                                              the names of resources,
-                                                              defined in spec.resourceClaims,
-                                                              that are used by this
-                                                              container. \n This is
-                                                              an alpha field and requires
-                                                              enabling the DynamicResourceAllocation
-                                                              feature gate. \n This
-                                                              field is immutable.
-                                                              It can only be set for
-                                                              containers."
-                                                            items:
-                                                              description: ResourceClaim
-                                                                references one entry
-                                                                in PodSpec.ResourceClaims.
-                                                              properties:
-                                                                name:
-                                                                  description: Name
-                                                                    must match the
-                                                                    name of one entry
-                                                                    in pod.spec.resourceClaims
-                                                                    of the Pod where
-                                                                    this field is
-                                                                    used. It makes
-                                                                    that resource
-                                                                    available inside
-                                                                    a container.
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                            type: array
-                                                            x-kubernetes-list-map-keys:
-                                                            - name
-                                                            x-kubernetes-list-type: map
                                                           limits:
                                                             additionalProperties:
                                                               anyOf:
@@ -12106,6 +12746,41 @@ spec:
                                                           is the name of the StorageClass
                                                           required by the claim. More
                                                           info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        description: 'volumeAttributesClassName
+                                                          may be used to set the VolumeAttributesClass
+                                                          used by this claim. If specified,
+                                                          the CSI driver will create
+                                                          or update the volume with
+                                                          the attributes defined in
+                                                          the corresponding VolumeAttributesClass.
+                                                          This has a different purpose
+                                                          than storageClassName, it
+                                                          can be changed after the
+                                                          claim is created. An empty
+                                                          string value means that
+                                                          no VolumeAttributesClass
+                                                          will be applied to the claim
+                                                          but it''s not allowed to
+                                                          reset this field to empty
+                                                          string once it is set. If
+                                                          unspecified and the PersistentVolumeClaim
+                                                          is unbound, the default
+                                                          VolumeAttributesClass will
+                                                          be set by the persistentvolume
+                                                          controller if it exists.
+                                                          If the resource referred
+                                                          to by volumeAttributesClass
+                                                          does not exist, this PersistentVolumeClaim
+                                                          will be set to a Pending
+                                                          state, as reflected by the
+                                                          modifyVolumeStatus field,
+                                                          until such as a resource
+                                                          exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                          (Alpha) Using this field
+                                                          requires the VolumeAttributesClass
+                                                          feature gate to be enabled.'
                                                         type: string
                                                       volumeMode:
                                                         description: volumeMode defines
@@ -12578,6 +13253,153 @@ spec:
                                                     be projected along with other
                                                     supported volume types
                                                   properties:
+                                                    clusterTrustBundle:
+                                                      description: "ClusterTrustBundle
+                                                        allows a pod to access the
+                                                        `.spec.trustBundle` field
+                                                        of ClusterTrustBundle objects
+                                                        in an auto-updating file.
+                                                        \n Alpha, gated by the ClusterTrustBundleProjection
+                                                        feature gate. \n ClusterTrustBundle
+                                                        objects can either be selected
+                                                        by name, or by the combination
+                                                        of signer name and a label
+                                                        selector. \n Kubelet performs
+                                                        aggressive normalization of
+                                                        the PEM contents written into
+                                                        the pod filesystem.  Esoteric
+                                                        PEM features such as inter-block
+                                                        comments and block headers
+                                                        are stripped.  Certificates
+                                                        are deduplicated. The ordering
+                                                        of certificates within the
+                                                        file is arbitrary, and Kubelet
+                                                        may change the order over
+                                                        time."
+                                                      properties:
+                                                        labelSelector:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this label selector.  Only
+                                                            has effect if signerName
+                                                            is set.  Mutually-exclusive
+                                                            with name.  If unset,
+                                                            interpreted as "match
+                                                            nothing".  If set but
+                                                            empty, interpreted as
+                                                            "match everything".
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          description: Select a single
+                                                            ClusterTrustBundle by
+                                                            object name.  Mutually-exclusive
+                                                            with signerName and labelSelector.
+                                                          type: string
+                                                        optional:
+                                                          description: If true, don't
+                                                            block pod startup if the
+                                                            referenced ClusterTrustBundle(s)
+                                                            aren't available.  If
+                                                            using name, then the named
+                                                            ClusterTrustBundle is
+                                                            allowed not to exist.  If
+                                                            using signerName, then
+                                                            the combination of signerName
+                                                            and labelSelector is allowed
+                                                            to match zero ClusterTrustBundles.
+                                                          type: boolean
+                                                        path:
+                                                          description: Relative path
+                                                            from the volume root to
+                                                            write the bundle.
+                                                          type: string
+                                                        signerName:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this signer name.
+                                                            Mutually-exclusive with
+                                                            name.  The contents of
+                                                            all selected ClusterTrustBundles
+                                                            will be unified and deduplicated.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
                                                     configMap:
                                                       description: configMap information
                                                         about the configMap data to
@@ -13575,32 +14397,6 @@ spec:
                                           than capacity recorded in the status field
                                           of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         properties:
-                                          claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
-                                            items:
-                                              description: ResourceClaim references
-                                                one entry in PodSpec.ResourceClaims.
-                                              properties:
-                                                name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
-                                                    inside a container.
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                            - name
-                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -13685,6 +14481,30 @@ spec:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: 'volumeAttributesClassName may
+                                          be used to set the VolumeAttributesClass
+                                          used by this claim. If specified, the CSI
+                                          driver will create or update the volume
+                                          with the attributes defined in the corresponding
+                                          VolumeAttributesClass. This has a different
+                                          purpose than storageClassName, it can be
+                                          changed after the claim is created. An empty
+                                          string value means that no VolumeAttributesClass
+                                          will be applied to the claim but it''s not
+                                          allowed to reset this field to empty string
+                                          once it is set. If unspecified and the PersistentVolumeClaim
+                                          is unbound, the default VolumeAttributesClass
+                                          will be set by the persistentvolume controller
+                                          if it exists. If the resource referred to
+                                          by volumeAttributesClass does not exist,
+                                          this PersistentVolumeClaim will be set to
+                                          a Pending state, as reflected by the modifyVolumeStatus
+                                          field, until such as a resource exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                          (Alpha) Using this field requires the VolumeAttributesClass
+                                          feature gate to be enabled.'
                                         type: string
                                       volumeMode:
                                         description: volumeMode defines what type
@@ -14230,6 +15050,19 @@ spec:
                                                     required:
                                                     - port
                                                     type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
                                                       is NOT supported as a LifecycleHandler
@@ -14360,6 +15193,19 @@ spec:
                                                         type: string
                                                     required:
                                                     - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
                                                     type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
@@ -15847,7 +16693,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -15920,6 +16768,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -16079,7 +16988,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -16147,6 +17058,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -16297,7 +17263,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -16370,6 +17338,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -16529,7 +17558,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -16597,6 +17628,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -18771,42 +19857,6 @@ spec:
                                                           status field of the claim.
                                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                         properties:
-                                                          claims:
-                                                            description: "Claims lists
-                                                              the names of resources,
-                                                              defined in spec.resourceClaims,
-                                                              that are used by this
-                                                              container. \n This is
-                                                              an alpha field and requires
-                                                              enabling the DynamicResourceAllocation
-                                                              feature gate. \n This
-                                                              field is immutable.
-                                                              It can only be set for
-                                                              containers."
-                                                            items:
-                                                              description: ResourceClaim
-                                                                references one entry
-                                                                in PodSpec.ResourceClaims.
-                                                              properties:
-                                                                name:
-                                                                  description: Name
-                                                                    must match the
-                                                                    name of one entry
-                                                                    in pod.spec.resourceClaims
-                                                                    of the Pod where
-                                                                    this field is
-                                                                    used. It makes
-                                                                    that resource
-                                                                    available inside
-                                                                    a container.
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                            type: array
-                                                            x-kubernetes-list-map-keys:
-                                                            - name
-                                                            x-kubernetes-list-type: map
                                                           limits:
                                                             additionalProperties:
                                                               anyOf:
@@ -18921,6 +19971,41 @@ spec:
                                                           is the name of the StorageClass
                                                           required by the claim. More
                                                           info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        description: 'volumeAttributesClassName
+                                                          may be used to set the VolumeAttributesClass
+                                                          used by this claim. If specified,
+                                                          the CSI driver will create
+                                                          or update the volume with
+                                                          the attributes defined in
+                                                          the corresponding VolumeAttributesClass.
+                                                          This has a different purpose
+                                                          than storageClassName, it
+                                                          can be changed after the
+                                                          claim is created. An empty
+                                                          string value means that
+                                                          no VolumeAttributesClass
+                                                          will be applied to the claim
+                                                          but it''s not allowed to
+                                                          reset this field to empty
+                                                          string once it is set. If
+                                                          unspecified and the PersistentVolumeClaim
+                                                          is unbound, the default
+                                                          VolumeAttributesClass will
+                                                          be set by the persistentvolume
+                                                          controller if it exists.
+                                                          If the resource referred
+                                                          to by volumeAttributesClass
+                                                          does not exist, this PersistentVolumeClaim
+                                                          will be set to a Pending
+                                                          state, as reflected by the
+                                                          modifyVolumeStatus field,
+                                                          until such as a resource
+                                                          exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                          (Alpha) Using this field
+                                                          requires the VolumeAttributesClass
+                                                          feature gate to be enabled.'
                                                         type: string
                                                       volumeMode:
                                                         description: volumeMode defines
@@ -19393,6 +20478,153 @@ spec:
                                                     be projected along with other
                                                     supported volume types
                                                   properties:
+                                                    clusterTrustBundle:
+                                                      description: "ClusterTrustBundle
+                                                        allows a pod to access the
+                                                        `.spec.trustBundle` field
+                                                        of ClusterTrustBundle objects
+                                                        in an auto-updating file.
+                                                        \n Alpha, gated by the ClusterTrustBundleProjection
+                                                        feature gate. \n ClusterTrustBundle
+                                                        objects can either be selected
+                                                        by name, or by the combination
+                                                        of signer name and a label
+                                                        selector. \n Kubelet performs
+                                                        aggressive normalization of
+                                                        the PEM contents written into
+                                                        the pod filesystem.  Esoteric
+                                                        PEM features such as inter-block
+                                                        comments and block headers
+                                                        are stripped.  Certificates
+                                                        are deduplicated. The ordering
+                                                        of certificates within the
+                                                        file is arbitrary, and Kubelet
+                                                        may change the order over
+                                                        time."
+                                                      properties:
+                                                        labelSelector:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this label selector.  Only
+                                                            has effect if signerName
+                                                            is set.  Mutually-exclusive
+                                                            with name.  If unset,
+                                                            interpreted as "match
+                                                            nothing".  If set but
+                                                            empty, interpreted as
+                                                            "match everything".
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          description: Select a single
+                                                            ClusterTrustBundle by
+                                                            object name.  Mutually-exclusive
+                                                            with signerName and labelSelector.
+                                                          type: string
+                                                        optional:
+                                                          description: If true, don't
+                                                            block pod startup if the
+                                                            referenced ClusterTrustBundle(s)
+                                                            aren't available.  If
+                                                            using name, then the named
+                                                            ClusterTrustBundle is
+                                                            allowed not to exist.  If
+                                                            using signerName, then
+                                                            the combination of signerName
+                                                            and labelSelector is allowed
+                                                            to match zero ClusterTrustBundles.
+                                                          type: boolean
+                                                        path:
+                                                          description: Relative path
+                                                            from the volume root to
+                                                            write the bundle.
+                                                          type: string
+                                                        signerName:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this signer name.
+                                                            Mutually-exclusive with
+                                                            name.  The contents of
+                                                            all selected ClusterTrustBundles
+                                                            will be unified and deduplicated.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
                                                     configMap:
                                                       description: configMap information
                                                         about the configMap data to
@@ -20390,32 +21622,6 @@ spec:
                                           than capacity recorded in the status field
                                           of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         properties:
-                                          claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
-                                            items:
-                                              description: ResourceClaim references
-                                                one entry in PodSpec.ResourceClaims.
-                                              properties:
-                                                name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
-                                                    inside a container.
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                            - name
-                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -20500,6 +21706,30 @@ spec:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: 'volumeAttributesClassName may
+                                          be used to set the VolumeAttributesClass
+                                          used by this claim. If specified, the CSI
+                                          driver will create or update the volume
+                                          with the attributes defined in the corresponding
+                                          VolumeAttributesClass. This has a different
+                                          purpose than storageClassName, it can be
+                                          changed after the claim is created. An empty
+                                          string value means that no VolumeAttributesClass
+                                          will be applied to the claim but it''s not
+                                          allowed to reset this field to empty string
+                                          once it is set. If unspecified and the PersistentVolumeClaim
+                                          is unbound, the default VolumeAttributesClass
+                                          will be set by the persistentvolume controller
+                                          if it exists. If the resource referred to
+                                          by volumeAttributesClass does not exist,
+                                          this PersistentVolumeClaim will be set to
+                                          a Pending state, as reflected by the modifyVolumeStatus
+                                          field, until such as a resource exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                          (Alpha) Using this field requires the VolumeAttributesClass
+                                          feature gate to be enabled.'
                                         type: string
                                       volumeMode:
                                         description: volumeMode defines what type
@@ -21044,6 +22274,19 @@ spec:
                                                     required:
                                                     - port
                                                     type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
                                                       is NOT supported as a LifecycleHandler
@@ -21174,6 +22417,19 @@ spec:
                                                         type: string
                                                     required:
                                                     - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
                                                     type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
@@ -22661,7 +23917,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -22734,6 +23992,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -22893,7 +24212,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -22961,6 +24282,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -23111,7 +24487,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -23184,6 +24562,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -23343,7 +24782,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -23411,6 +24852,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -25585,42 +27081,6 @@ spec:
                                                           status field of the claim.
                                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                         properties:
-                                                          claims:
-                                                            description: "Claims lists
-                                                              the names of resources,
-                                                              defined in spec.resourceClaims,
-                                                              that are used by this
-                                                              container. \n This is
-                                                              an alpha field and requires
-                                                              enabling the DynamicResourceAllocation
-                                                              feature gate. \n This
-                                                              field is immutable.
-                                                              It can only be set for
-                                                              containers."
-                                                            items:
-                                                              description: ResourceClaim
-                                                                references one entry
-                                                                in PodSpec.ResourceClaims.
-                                                              properties:
-                                                                name:
-                                                                  description: Name
-                                                                    must match the
-                                                                    name of one entry
-                                                                    in pod.spec.resourceClaims
-                                                                    of the Pod where
-                                                                    this field is
-                                                                    used. It makes
-                                                                    that resource
-                                                                    available inside
-                                                                    a container.
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                            type: array
-                                                            x-kubernetes-list-map-keys:
-                                                            - name
-                                                            x-kubernetes-list-type: map
                                                           limits:
                                                             additionalProperties:
                                                               anyOf:
@@ -25735,6 +27195,41 @@ spec:
                                                           is the name of the StorageClass
                                                           required by the claim. More
                                                           info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        description: 'volumeAttributesClassName
+                                                          may be used to set the VolumeAttributesClass
+                                                          used by this claim. If specified,
+                                                          the CSI driver will create
+                                                          or update the volume with
+                                                          the attributes defined in
+                                                          the corresponding VolumeAttributesClass.
+                                                          This has a different purpose
+                                                          than storageClassName, it
+                                                          can be changed after the
+                                                          claim is created. An empty
+                                                          string value means that
+                                                          no VolumeAttributesClass
+                                                          will be applied to the claim
+                                                          but it''s not allowed to
+                                                          reset this field to empty
+                                                          string once it is set. If
+                                                          unspecified and the PersistentVolumeClaim
+                                                          is unbound, the default
+                                                          VolumeAttributesClass will
+                                                          be set by the persistentvolume
+                                                          controller if it exists.
+                                                          If the resource referred
+                                                          to by volumeAttributesClass
+                                                          does not exist, this PersistentVolumeClaim
+                                                          will be set to a Pending
+                                                          state, as reflected by the
+                                                          modifyVolumeStatus field,
+                                                          until such as a resource
+                                                          exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                          (Alpha) Using this field
+                                                          requires the VolumeAttributesClass
+                                                          feature gate to be enabled.'
                                                         type: string
                                                       volumeMode:
                                                         description: volumeMode defines
@@ -26207,6 +27702,153 @@ spec:
                                                     be projected along with other
                                                     supported volume types
                                                   properties:
+                                                    clusterTrustBundle:
+                                                      description: "ClusterTrustBundle
+                                                        allows a pod to access the
+                                                        `.spec.trustBundle` field
+                                                        of ClusterTrustBundle objects
+                                                        in an auto-updating file.
+                                                        \n Alpha, gated by the ClusterTrustBundleProjection
+                                                        feature gate. \n ClusterTrustBundle
+                                                        objects can either be selected
+                                                        by name, or by the combination
+                                                        of signer name and a label
+                                                        selector. \n Kubelet performs
+                                                        aggressive normalization of
+                                                        the PEM contents written into
+                                                        the pod filesystem.  Esoteric
+                                                        PEM features such as inter-block
+                                                        comments and block headers
+                                                        are stripped.  Certificates
+                                                        are deduplicated. The ordering
+                                                        of certificates within the
+                                                        file is arbitrary, and Kubelet
+                                                        may change the order over
+                                                        time."
+                                                      properties:
+                                                        labelSelector:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this label selector.  Only
+                                                            has effect if signerName
+                                                            is set.  Mutually-exclusive
+                                                            with name.  If unset,
+                                                            interpreted as "match
+                                                            nothing".  If set but
+                                                            empty, interpreted as
+                                                            "match everything".
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          description: Select a single
+                                                            ClusterTrustBundle by
+                                                            object name.  Mutually-exclusive
+                                                            with signerName and labelSelector.
+                                                          type: string
+                                                        optional:
+                                                          description: If true, don't
+                                                            block pod startup if the
+                                                            referenced ClusterTrustBundle(s)
+                                                            aren't available.  If
+                                                            using name, then the named
+                                                            ClusterTrustBundle is
+                                                            allowed not to exist.  If
+                                                            using signerName, then
+                                                            the combination of signerName
+                                                            and labelSelector is allowed
+                                                            to match zero ClusterTrustBundles.
+                                                          type: boolean
+                                                        path:
+                                                          description: Relative path
+                                                            from the volume root to
+                                                            write the bundle.
+                                                          type: string
+                                                        signerName:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this signer name.
+                                                            Mutually-exclusive with
+                                                            name.  The contents of
+                                                            all selected ClusterTrustBundles
+                                                            will be unified and deduplicated.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
                                                     configMap:
                                                       description: configMap information
                                                         about the configMap data to
@@ -27204,32 +28846,6 @@ spec:
                                           than capacity recorded in the status field
                                           of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         properties:
-                                          claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
-                                            items:
-                                              description: ResourceClaim references
-                                                one entry in PodSpec.ResourceClaims.
-                                              properties:
-                                                name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
-                                                    inside a container.
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                            - name
-                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -27314,6 +28930,30 @@ spec:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: 'volumeAttributesClassName may
+                                          be used to set the VolumeAttributesClass
+                                          used by this claim. If specified, the CSI
+                                          driver will create or update the volume
+                                          with the attributes defined in the corresponding
+                                          VolumeAttributesClass. This has a different
+                                          purpose than storageClassName, it can be
+                                          changed after the claim is created. An empty
+                                          string value means that no VolumeAttributesClass
+                                          will be applied to the claim but it''s not
+                                          allowed to reset this field to empty string
+                                          once it is set. If unspecified and the PersistentVolumeClaim
+                                          is unbound, the default VolumeAttributesClass
+                                          will be set by the persistentvolume controller
+                                          if it exists. If the resource referred to
+                                          by volumeAttributesClass does not exist,
+                                          this PersistentVolumeClaim will be set to
+                                          a Pending state, as reflected by the modifyVolumeStatus
+                                          field, until such as a resource exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                          (Alpha) Using this field requires the VolumeAttributesClass
+                                          feature gate to be enabled.'
                                         type: string
                                       volumeMode:
                                         description: volumeMode defines what type
@@ -27858,6 +29498,19 @@ spec:
                                                     required:
                                                     - port
                                                     type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
                                                       is NOT supported as a LifecycleHandler
@@ -27988,6 +29641,19 @@ spec:
                                                         type: string
                                                     required:
                                                     - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents
+                                                      the duration that the container
+                                                      should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the
+                                                          number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
                                                     type: object
                                                   tcpSocket:
                                                     description: Deprecated. TCPSocket
@@ -29475,7 +31141,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -29548,6 +31216,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -29707,7 +31436,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -29775,6 +31506,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -29925,7 +31711,9 @@ spec:
                                                       labelSelector:
                                                         description: A label query
                                                           over a set of resources,
-                                                          in this case pods.
+                                                          in this case pods. If it's
+                                                          null, this PodAffinityTerm
+                                                          matches with no Pods.
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions
@@ -29998,6 +31786,67 @@ spec:
                                                             type: object
                                                         type: object
                                                         x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: MatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key in (value)` to select
+                                                          the group of existing pods
+                                                          which pods will be taken
+                                                          into consideration for the
+                                                          incoming pod's pod (anti)
+                                                          affinity. Keys that don't
+                                                          exist in the incoming pod
+                                                          labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MatchLabelKeys cannot be
+                                                          set when LabelSelector isn't
+                                                          set. This is an alpha field
+                                                          and requires enabling MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: MismatchLabelKeys
+                                                          is a set of pod label keys
+                                                          to select which pods will
+                                                          be taken into consideration.
+                                                          The keys are used to lookup
+                                                          values from the incoming
+                                                          pod labels, those key-value
+                                                          labels are merged with `LabelSelector`
+                                                          as `key notin (value)` to
+                                                          select the group of existing
+                                                          pods which pods will be
+                                                          taken into consideration
+                                                          for the incoming pod's pod
+                                                          (anti) affinity. Keys that
+                                                          don't exist in the incoming
+                                                          pod labels will be ignored.
+                                                          The default value is empty.
+                                                          The same key is forbidden
+                                                          to exist in both MismatchLabelKeys
+                                                          and LabelSelector. Also,
+                                                          MismatchLabelKeys cannot
+                                                          be set when LabelSelector
+                                                          isn't set. This is an alpha
+                                                          field and requires enabling
+                                                          MatchLabelKeysInPodAffinity
+                                                          feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: A label query
                                                           over the set of namespaces
@@ -30157,7 +32006,9 @@ spec:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
-                                                      case pods.
+                                                      case pods. If it's null, this
+                                                      PodAffinityTerm matches with
+                                                      no Pods.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -30225,6 +32076,61 @@ spec:
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: MatchLabelKeys is
+                                                      a set of pod label keys to select
+                                                      which pods will be taken into
+                                                      consideration. The keys are
+                                                      used to lookup values from the
+                                                      incoming pod labels, those key-value
+                                                      labels are merged with `LabelSelector`
+                                                      as `key in (value)` to select
+                                                      the group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MatchLabelKeys
+                                                      and LabelSelector. Also, MatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: MismatchLabelKeys
+                                                      is a set of pod label keys to
+                                                      select which pods will be taken
+                                                      into consideration. The keys
+                                                      are used to lookup values from
+                                                      the incoming pod labels, those
+                                                      key-value labels are merged
+                                                      with `LabelSelector` as `key
+                                                      notin (value)` to select the
+                                                      group of existing pods which
+                                                      pods will be taken into consideration
+                                                      for the incoming pod's pod (anti)
+                                                      affinity. Keys that don't exist
+                                                      in the incoming pod labels will
+                                                      be ignored. The default value
+                                                      is empty. The same key is forbidden
+                                                      to exist in both MismatchLabelKeys
+                                                      and LabelSelector. Also, MismatchLabelKeys
+                                                      cannot be set when LabelSelector
+                                                      isn't set. This is an alpha
+                                                      field and requires enabling
+                                                      MatchLabelKeysInPodAffinity
+                                                      feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: A label query over
                                                       the set of namespaces that the
@@ -32399,42 +34305,6 @@ spec:
                                                           status field of the claim.
                                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                         properties:
-                                                          claims:
-                                                            description: "Claims lists
-                                                              the names of resources,
-                                                              defined in spec.resourceClaims,
-                                                              that are used by this
-                                                              container. \n This is
-                                                              an alpha field and requires
-                                                              enabling the DynamicResourceAllocation
-                                                              feature gate. \n This
-                                                              field is immutable.
-                                                              It can only be set for
-                                                              containers."
-                                                            items:
-                                                              description: ResourceClaim
-                                                                references one entry
-                                                                in PodSpec.ResourceClaims.
-                                                              properties:
-                                                                name:
-                                                                  description: Name
-                                                                    must match the
-                                                                    name of one entry
-                                                                    in pod.spec.resourceClaims
-                                                                    of the Pod where
-                                                                    this field is
-                                                                    used. It makes
-                                                                    that resource
-                                                                    available inside
-                                                                    a container.
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                            type: array
-                                                            x-kubernetes-list-map-keys:
-                                                            - name
-                                                            x-kubernetes-list-type: map
                                                           limits:
                                                             additionalProperties:
                                                               anyOf:
@@ -32549,6 +34419,41 @@ spec:
                                                           is the name of the StorageClass
                                                           required by the claim. More
                                                           info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        description: 'volumeAttributesClassName
+                                                          may be used to set the VolumeAttributesClass
+                                                          used by this claim. If specified,
+                                                          the CSI driver will create
+                                                          or update the volume with
+                                                          the attributes defined in
+                                                          the corresponding VolumeAttributesClass.
+                                                          This has a different purpose
+                                                          than storageClassName, it
+                                                          can be changed after the
+                                                          claim is created. An empty
+                                                          string value means that
+                                                          no VolumeAttributesClass
+                                                          will be applied to the claim
+                                                          but it''s not allowed to
+                                                          reset this field to empty
+                                                          string once it is set. If
+                                                          unspecified and the PersistentVolumeClaim
+                                                          is unbound, the default
+                                                          VolumeAttributesClass will
+                                                          be set by the persistentvolume
+                                                          controller if it exists.
+                                                          If the resource referred
+                                                          to by volumeAttributesClass
+                                                          does not exist, this PersistentVolumeClaim
+                                                          will be set to a Pending
+                                                          state, as reflected by the
+                                                          modifyVolumeStatus field,
+                                                          until such as a resource
+                                                          exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                          (Alpha) Using this field
+                                                          requires the VolumeAttributesClass
+                                                          feature gate to be enabled.'
                                                         type: string
                                                       volumeMode:
                                                         description: volumeMode defines
@@ -33021,6 +34926,153 @@ spec:
                                                     be projected along with other
                                                     supported volume types
                                                   properties:
+                                                    clusterTrustBundle:
+                                                      description: "ClusterTrustBundle
+                                                        allows a pod to access the
+                                                        `.spec.trustBundle` field
+                                                        of ClusterTrustBundle objects
+                                                        in an auto-updating file.
+                                                        \n Alpha, gated by the ClusterTrustBundleProjection
+                                                        feature gate. \n ClusterTrustBundle
+                                                        objects can either be selected
+                                                        by name, or by the combination
+                                                        of signer name and a label
+                                                        selector. \n Kubelet performs
+                                                        aggressive normalization of
+                                                        the PEM contents written into
+                                                        the pod filesystem.  Esoteric
+                                                        PEM features such as inter-block
+                                                        comments and block headers
+                                                        are stripped.  Certificates
+                                                        are deduplicated. The ordering
+                                                        of certificates within the
+                                                        file is arbitrary, and Kubelet
+                                                        may change the order over
+                                                        time."
+                                                      properties:
+                                                        labelSelector:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this label selector.  Only
+                                                            has effect if signerName
+                                                            is set.  Mutually-exclusive
+                                                            with name.  If unset,
+                                                            interpreted as "match
+                                                            nothing".  If set but
+                                                            empty, interpreted as
+                                                            "match everything".
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          description: Select a single
+                                                            ClusterTrustBundle by
+                                                            object name.  Mutually-exclusive
+                                                            with signerName and labelSelector.
+                                                          type: string
+                                                        optional:
+                                                          description: If true, don't
+                                                            block pod startup if the
+                                                            referenced ClusterTrustBundle(s)
+                                                            aren't available.  If
+                                                            using name, then the named
+                                                            ClusterTrustBundle is
+                                                            allowed not to exist.  If
+                                                            using signerName, then
+                                                            the combination of signerName
+                                                            and labelSelector is allowed
+                                                            to match zero ClusterTrustBundles.
+                                                          type: boolean
+                                                        path:
+                                                          description: Relative path
+                                                            from the volume root to
+                                                            write the bundle.
+                                                          type: string
+                                                        signerName:
+                                                          description: Select all
+                                                            ClusterTrustBundles that
+                                                            match this signer name.
+                                                            Mutually-exclusive with
+                                                            name.  The contents of
+                                                            all selected ClusterTrustBundles
+                                                            will be unified and deduplicated.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
                                                     configMap:
                                                       description: configMap information
                                                         about the configMap data to
@@ -34018,32 +36070,6 @@ spec:
                                           than capacity recorded in the status field
                                           of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         properties:
-                                          claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
-                                            items:
-                                              description: ResourceClaim references
-                                                one entry in PodSpec.ResourceClaims.
-                                              properties:
-                                                name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
-                                                    inside a container.
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                            - name
-                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -34128,6 +36154,30 @@ spec:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
                                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: 'volumeAttributesClassName may
+                                          be used to set the VolumeAttributesClass
+                                          used by this claim. If specified, the CSI
+                                          driver will create or update the volume
+                                          with the attributes defined in the corresponding
+                                          VolumeAttributesClass. This has a different
+                                          purpose than storageClassName, it can be
+                                          changed after the claim is created. An empty
+                                          string value means that no VolumeAttributesClass
+                                          will be applied to the claim but it''s not
+                                          allowed to reset this field to empty string
+                                          once it is set. If unspecified and the PersistentVolumeClaim
+                                          is unbound, the default VolumeAttributesClass
+                                          will be set by the persistentvolume controller
+                                          if it exists. If the resource referred to
+                                          by volumeAttributesClass does not exist,
+                                          this PersistentVolumeClaim will be set to
+                                          a Pending state, as reflected by the modifyVolumeStatus
+                                          field, until such as a resource exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                          (Alpha) Using this field requires the VolumeAttributesClass
+                                          feature gate to be enabled.'
                                         type: string
                                       volumeMode:
                                         description: volumeMode defines what type
@@ -34584,6 +36634,19 @@ spec:
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
                                               description: Deprecated. TCPSocket is
                                                 NOT supported as a LifecycleHandler
@@ -34704,6 +36767,19 @@ spec:
                                                   type: string
                                               required:
                                               - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
                                               type: object
                                             tcpSocket:
                                               description: Deprecated. TCPSocket is
@@ -36055,7 +38131,8 @@ spec:
                                                 labelSelector:
                                                   description: A label query over
                                                     a set of resources, in this case
-                                                    pods.
+                                                    pods. If it's null, this PodAffinityTerm
+                                                    matches with no Pods.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -36118,6 +38195,58 @@ spec:
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  description: MatchLabelKeys is a
+                                                    set of pod label keys to select
+                                                    which pods will be taken into
+                                                    consideration. The keys are used
+                                                    to lookup values from the incoming
+                                                    pod labels, those key-value labels
+                                                    are merged with `LabelSelector`
+                                                    as `key in (value)` to select
+                                                    the group of existing pods which
+                                                    pods will be taken into consideration
+                                                    for the incoming pod's pod (anti)
+                                                    affinity. Keys that don't exist
+                                                    in the incoming pod labels will
+                                                    be ignored. The default value
+                                                    is empty. The same key is forbidden
+                                                    to exist in both MatchLabelKeys
+                                                    and LabelSelector. Also, MatchLabelKeys
+                                                    cannot be set when LabelSelector
+                                                    isn't set. This is an alpha field
+                                                    and requires enabling MatchLabelKeysInPodAffinity
+                                                    feature gate.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  description: MismatchLabelKeys is
+                                                    a set of pod label keys to select
+                                                    which pods will be taken into
+                                                    consideration. The keys are used
+                                                    to lookup values from the incoming
+                                                    pod labels, those key-value labels
+                                                    are merged with `LabelSelector`
+                                                    as `key notin (value)` to select
+                                                    the group of existing pods which
+                                                    pods will be taken into consideration
+                                                    for the incoming pod's pod (anti)
+                                                    affinity. Keys that don't exist
+                                                    in the incoming pod labels will
+                                                    be ignored. The default value
+                                                    is empty. The same key is forbidden
+                                                    to exist in both MismatchLabelKeys
+                                                    and LabelSelector. Also, MismatchLabelKeys
+                                                    cannot be set when LabelSelector
+                                                    isn't set. This is an alpha field
+                                                    and requires enabling MatchLabelKeysInPodAffinity
+                                                    feature gate.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -36257,7 +38386,9 @@ spec:
                                           properties:
                                             labelSelector:
                                               description: A label query over a set
-                                                of resources, in this case pods.
+                                                of resources, in this case pods. If
+                                                it's null, this PodAffinityTerm matches
+                                                with no Pods.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -36316,6 +38447,54 @@ spec:
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: MatchLabelKeys is a set
+                                                of pod label keys to select which
+                                                pods will be taken into consideration.
+                                                The keys are used to lookup values
+                                                from the incoming pod labels, those
+                                                key-value labels are merged with `LabelSelector`
+                                                as `key in (value)` to select the
+                                                group of existing pods which pods
+                                                will be taken into consideration for
+                                                the incoming pod's pod (anti) affinity.
+                                                Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default
+                                                value is empty. The same key is forbidden
+                                                to exist in both MatchLabelKeys and
+                                                LabelSelector. Also, MatchLabelKeys
+                                                cannot be set when LabelSelector isn't
+                                                set. This is an alpha field and requires
+                                                enabling MatchLabelKeysInPodAffinity
+                                                feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: MismatchLabelKeys is a
+                                                set of pod label keys to select which
+                                                pods will be taken into consideration.
+                                                The keys are used to lookup values
+                                                from the incoming pod labels, those
+                                                key-value labels are merged with `LabelSelector`
+                                                as `key notin (value)` to select the
+                                                group of existing pods which pods
+                                                will be taken into consideration for
+                                                the incoming pod's pod (anti) affinity.
+                                                Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default
+                                                value is empty. The same key is forbidden
+                                                to exist in both MismatchLabelKeys
+                                                and LabelSelector. Also, MismatchLabelKeys
+                                                cannot be set when LabelSelector isn't
+                                                set. This is an alpha field and requires
+                                                enabling MatchLabelKeysInPodAffinity
+                                                feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -36447,7 +38626,8 @@ spec:
                                                 labelSelector:
                                                   description: A label query over
                                                     a set of resources, in this case
-                                                    pods.
+                                                    pods. If it's null, this PodAffinityTerm
+                                                    matches with no Pods.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -36510,6 +38690,58 @@ spec:
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  description: MatchLabelKeys is a
+                                                    set of pod label keys to select
+                                                    which pods will be taken into
+                                                    consideration. The keys are used
+                                                    to lookup values from the incoming
+                                                    pod labels, those key-value labels
+                                                    are merged with `LabelSelector`
+                                                    as `key in (value)` to select
+                                                    the group of existing pods which
+                                                    pods will be taken into consideration
+                                                    for the incoming pod's pod (anti)
+                                                    affinity. Keys that don't exist
+                                                    in the incoming pod labels will
+                                                    be ignored. The default value
+                                                    is empty. The same key is forbidden
+                                                    to exist in both MatchLabelKeys
+                                                    and LabelSelector. Also, MatchLabelKeys
+                                                    cannot be set when LabelSelector
+                                                    isn't set. This is an alpha field
+                                                    and requires enabling MatchLabelKeysInPodAffinity
+                                                    feature gate.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  description: MismatchLabelKeys is
+                                                    a set of pod label keys to select
+                                                    which pods will be taken into
+                                                    consideration. The keys are used
+                                                    to lookup values from the incoming
+                                                    pod labels, those key-value labels
+                                                    are merged with `LabelSelector`
+                                                    as `key notin (value)` to select
+                                                    the group of existing pods which
+                                                    pods will be taken into consideration
+                                                    for the incoming pod's pod (anti)
+                                                    affinity. Keys that don't exist
+                                                    in the incoming pod labels will
+                                                    be ignored. The default value
+                                                    is empty. The same key is forbidden
+                                                    to exist in both MismatchLabelKeys
+                                                    and LabelSelector. Also, MismatchLabelKeys
+                                                    cannot be set when LabelSelector
+                                                    isn't set. This is an alpha field
+                                                    and requires enabling MatchLabelKeysInPodAffinity
+                                                    feature gate.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -36649,7 +38881,9 @@ spec:
                                           properties:
                                             labelSelector:
                                               description: A label query over a set
-                                                of resources, in this case pods.
+                                                of resources, in this case pods. If
+                                                it's null, this PodAffinityTerm matches
+                                                with no Pods.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -36708,6 +38942,54 @@ spec:
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: MatchLabelKeys is a set
+                                                of pod label keys to select which
+                                                pods will be taken into consideration.
+                                                The keys are used to lookup values
+                                                from the incoming pod labels, those
+                                                key-value labels are merged with `LabelSelector`
+                                                as `key in (value)` to select the
+                                                group of existing pods which pods
+                                                will be taken into consideration for
+                                                the incoming pod's pod (anti) affinity.
+                                                Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default
+                                                value is empty. The same key is forbidden
+                                                to exist in both MatchLabelKeys and
+                                                LabelSelector. Also, MatchLabelKeys
+                                                cannot be set when LabelSelector isn't
+                                                set. This is an alpha field and requires
+                                                enabling MatchLabelKeysInPodAffinity
+                                                feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: MismatchLabelKeys is a
+                                                set of pod label keys to select which
+                                                pods will be taken into consideration.
+                                                The keys are used to lookup values
+                                                from the incoming pod labels, those
+                                                key-value labels are merged with `LabelSelector`
+                                                as `key notin (value)` to select the
+                                                group of existing pods which pods
+                                                will be taken into consideration for
+                                                the incoming pod's pod (anti) affinity.
+                                                Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default
+                                                value is empty. The same key is forbidden
+                                                to exist in both MismatchLabelKeys
+                                                and LabelSelector. Also, MismatchLabelKeys
+                                                cannot be set when LabelSelector isn't
+                                                set. This is an alpha field and requires
+                                                enabling MatchLabelKeysInPodAffinity
+                                                feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -38691,38 +40973,6 @@ spec:
                                                     field of the claim. More info:
                                                     https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                   properties:
-                                                    claims:
-                                                      description: "Claims lists the
-                                                        names of resources, defined
-                                                        in spec.resourceClaims, that
-                                                        are used by this container.
-                                                        \n This is an alpha field
-                                                        and requires enabling the
-                                                        DynamicResourceAllocation
-                                                        feature gate. \n This field
-                                                        is immutable. It can only
-                                                        be set for containers."
-                                                      items:
-                                                        description: ResourceClaim
-                                                          references one entry in
-                                                          PodSpec.ResourceClaims.
-                                                        properties:
-                                                          name:
-                                                            description: Name must
-                                                              match the name of one
-                                                              entry in pod.spec.resourceClaims
-                                                              of the Pod where this
-                                                              field is used. It makes
-                                                              that resource available
-                                                              inside a container.
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        type: object
-                                                      type: array
-                                                      x-kubernetes-list-map-keys:
-                                                      - name
-                                                      x-kubernetes-list-type: map
                                                     limits:
                                                       additionalProperties:
                                                         anyOf:
@@ -38823,6 +41073,35 @@ spec:
                                                   description: 'storageClassName is
                                                     the name of the StorageClass required
                                                     by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  description: 'volumeAttributesClassName
+                                                    may be used to set the VolumeAttributesClass
+                                                    used by this claim. If specified,
+                                                    the CSI driver will create or
+                                                    update the volume with the attributes
+                                                    defined in the corresponding VolumeAttributesClass.
+                                                    This has a different purpose than
+                                                    storageClassName, it can be changed
+                                                    after the claim is created. An
+                                                    empty string value means that
+                                                    no VolumeAttributesClass will
+                                                    be applied to the claim but it''s
+                                                    not allowed to reset this field
+                                                    to empty string once it is set.
+                                                    If unspecified and the PersistentVolumeClaim
+                                                    is unbound, the default VolumeAttributesClass
+                                                    will be set by the persistentvolume
+                                                    controller if it exists. If the
+                                                    resource referred to by volumeAttributesClass
+                                                    does not exist, this PersistentVolumeClaim
+                                                    will be set to a Pending state,
+                                                    as reflected by the modifyVolumeStatus
+                                                    field, until such as a resource
+                                                    exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                    (Alpha) Using this field requires
+                                                    the VolumeAttributesClass feature
+                                                    gate to be enabled.'
                                                   type: string
                                                 volumeMode:
                                                   description: volumeMode defines
@@ -39261,6 +41540,133 @@ spec:
                                             description: Projection that may be projected
                                               along with other supported volume types
                                             properties:
+                                              clusterTrustBundle:
+                                                description: "ClusterTrustBundle allows
+                                                  a pod to access the `.spec.trustBundle`
+                                                  field of ClusterTrustBundle objects
+                                                  in an auto-updating file. \n Alpha,
+                                                  gated by the ClusterTrustBundleProjection
+                                                  feature gate. \n ClusterTrustBundle
+                                                  objects can either be selected by
+                                                  name, or by the combination of signer
+                                                  name and a label selector. \n Kubelet
+                                                  performs aggressive normalization
+                                                  of the PEM contents written into
+                                                  the pod filesystem.  Esoteric PEM
+                                                  features such as inter-block comments
+                                                  and block headers are stripped.
+                                                  \ Certificates are deduplicated.
+                                                  The ordering of certificates within
+                                                  the file is arbitrary, and Kubelet
+                                                  may change the order over time."
+                                                properties:
+                                                  labelSelector:
+                                                    description: Select all ClusterTrustBundles
+                                                      that match this label selector.  Only
+                                                      has effect if signerName is
+                                                      set.  Mutually-exclusive with
+                                                      name.  If unset, interpreted
+                                                      as "match nothing".  If set
+                                                      but empty, interpreted as "match
+                                                      everything".
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values,
+                                                            a key, and an operator
+                                                            that relates the key and
+                                                            values.
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator
+                                                                represents a key's
+                                                                relationship to a
+                                                                set of values. Valid
+                                                                operators are In,
+                                                                NotIn, Exists and
+                                                                DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values
+                                                                is an array of string
+                                                                values. If the operator
+                                                                is In or NotIn, the
+                                                                values array must
+                                                                be non-empty. If the
+                                                                operator is Exists
+                                                                or DoesNotExist, the
+                                                                values array must
+                                                                be empty. This array
+                                                                is replaced during
+                                                                a strategic merge
+                                                                patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is
+                                                          a map of {key,value} pairs.
+                                                          A single {key,value} in
+                                                          the matchLabels map is equivalent
+                                                          to an element of matchExpressions,
+                                                          whose key field is "key",
+                                                          the operator is "In", and
+                                                          the values array contains
+                                                          only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    description: Select a single ClusterTrustBundle
+                                                      by object name.  Mutually-exclusive
+                                                      with signerName and labelSelector.
+                                                    type: string
+                                                  optional:
+                                                    description: If true, don't block
+                                                      pod startup if the referenced
+                                                      ClusterTrustBundle(s) aren't
+                                                      available.  If using name, then
+                                                      the named ClusterTrustBundle
+                                                      is allowed not to exist.  If
+                                                      using signerName, then the combination
+                                                      of signerName and labelSelector
+                                                      is allowed to match zero ClusterTrustBundles.
+                                                    type: boolean
+                                                  path:
+                                                    description: Relative path from
+                                                      the volume root to write the
+                                                      bundle.
+                                                    type: string
+                                                  signerName:
+                                                    description: Select all ClusterTrustBundles
+                                                      that match this signer name.
+                                                      Mutually-exclusive with name.  The
+                                                      contents of all selected ClusterTrustBundles
+                                                      will be unified and deduplicated.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
                                               configMap:
                                                 description: configMap information
                                                   about the configMap data to project
@@ -40156,31 +42562,6 @@ spec:
                                     value but must still be higher than capacity recorded
                                     in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                   properties:
-                                    claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
-                                      items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
-                                        properties:
-                                          name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
                                     limits:
                                       additionalProperties:
                                         anyOf:
@@ -40263,6 +42644,28 @@ spec:
                                     StorageClass required by the claim. More info:
                                     https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
+                                volumeAttributesClassName:
+                                  description: 'volumeAttributesClassName may be used
+                                    to set the VolumeAttributesClass used by this
+                                    claim. If specified, the CSI driver will create
+                                    or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This
+                                    has a different purpose than storageClassName,
+                                    it can be changed after the claim is created.
+                                    An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it''s not allowed
+                                    to reset this field to empty string once it is
+                                    set. If unspecified and the PersistentVolumeClaim
+                                    is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller
+                                    if it exists. If the resource referred to by volumeAttributesClass
+                                    does not exist, this PersistentVolumeClaim will
+                                    be set to a Pending state, as reflected by the
+                                    modifyVolumeStatus field, until such as a resource
+                                    exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                    (Alpha) Using this field requires the VolumeAttributesClass
+                                    feature gate to be enabled.'
+                                  type: string
                                 volumeMode:
                                   description: volumeMode defines what type of volume
                                     is required by the claim. Value of Filesystem
@@ -40275,6 +42678,8 @@ spec:
                               type: object
                           type: object
                         type: array
+                    required:
+                    - replicas
                     type: object
                 type: object
               configuration:

--- a/charts/risingwave-operator/templates/clusterrole.yaml
+++ b/charts/risingwave-operator/templates/clusterrole.yaml
@@ -8,14 +8,12 @@ kind: ClusterRole
 metadata:
   name: {{ include "risingwave-operator.fullname" . }}
   labels:
+    apps.kubernetes.io/component: manager
     {{- include "risingwave-operator.labels" . | nindent 4 }}
   {{- $annotations := (include "risingwave-operator.annotations" . ) | trim }}
   {{- if $annotations }}
   annotations:
     {{ nindent 4 $annotations }}
-  {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
 - apiGroups:

--- a/charts/risingwave-operator/templates/clusterrolebinding.yaml
+++ b/charts/risingwave-operator/templates/clusterrolebinding.yaml
@@ -8,14 +8,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "risingwave-operator.fullname" . }}
   labels:
+    apps.kubernetes.io/component: manager
     {{- include "risingwave-operator.labels" . | nindent 4 }}
   {{- $annotations := (include "risingwave-operator.annotations" . ) | trim }}
   {{- if $annotations }}
   annotations:
     {{ nindent 4 $annotations }}
-  {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/risingwave-operator/templates/deployment.yaml
+++ b/charts/risingwave-operator/templates/deployment.yaml
@@ -15,9 +15,6 @@ metadata:
   annotations:
     {{ nindent 4 $annotations }}
   {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   {{- if .Values.manager.updateStrategy }}
   strategy:
@@ -110,7 +107,11 @@ spec:
         - --leader-elect
         - --zap-devel=true
         - --health-probe-bind-address=:8081
+        {{- if .Values.proxy.enabled }}
         - --metrics-bind-address=127.0.0.1:8080
+        {{- else }}
+        - --metrics-bind-address=:8080
+        {{- end }}
         {{- if .Values.manager.extraArgs }}
         {{- range .Values.manager.extraArgs }}
         - {{ . }}
@@ -124,6 +125,11 @@ spec:
         - containerPort: 9443
           name: webhook
           protocol: TCP
+        {{- if not .Values.proxy.enabled }}
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        {{- end }}
         {{- if not .Values.diagnosticMode.enabled }}
         livenessProbe:
           httpGet:
@@ -140,6 +146,7 @@ spec:
         {{- end }}
         resources:
         {{- toYaml .Values.manager.resources | nindent 10 }}
+      {{- if .Values.proxy.enabled }}
       - name: proxy
         image: {{ .Values.proxy.image }}
         imagePullPolicy: {{ .Values.proxy.imagePullPolicy }}
@@ -154,4 +161,5 @@ spec:
           protocol: TCP
       {{- if .Values.manager.additionalContainers }}
       {{- toYaml .Values.manager.additionalContainers | nindent 6 }}
+      {{- end }}
       {{- end }}

--- a/charts/risingwave-operator/templates/podmonitor.yaml
+++ b/charts/risingwave-operator/templates/podmonitor.yaml
@@ -1,0 +1,54 @@
+{{/*
+Copyright RisingWave Labs
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.monitor.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "risingwave-operator.fullname" . }}
+  namespace: {{ ternary .Values.monitor.podMonitor.namespace .Release.Namespace (not (empty .Values.monitor.podMonitor.namespace)) }}
+  labels:
+    apps.kubernetes.io/component: manager
+    {{- include "risingwave-operator.labels" . | nindent 4 }}
+    {{- if .Values.monitor.podMonitor.additionalLabels }}
+    {{ .Values.monitor.podMonitor.additionalLabels  toYaml | nindent 4 }}
+    {{- end }}
+  {{- $annotations := (include "risingwave-operator.annotations" . ) | trim }}
+  {{- if $annotations }}
+  annotations:
+    {{ nindent 4 $annotations }}
+  {{- end }}
+spec:
+  podTargetLabels:
+  - app.kubernetes.io/name
+  - app.kubernetes.io/instance
+  - apps.kubernetes.io/component
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "risingwave-operator.selectorLabels" . | nindent 6 }}
+      apps.kubernetes.io/component: manager
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+      {{- if .Values.monitor.podMonitor.interval }}
+    interval: {{ .Values.monitor.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.monitor.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.monitor.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.monitor.podMonitor.scheme }}
+    scheme: {{ .Values.monitor.podMonitor.scheme }}
+      {{- end }}
+      {{- if .Values.monitor.podMonitor.tlsConfig }}
+    tlsConfig: {{- include "common.tplvalues.render" ( dict "value" .Values.monitor.podMonitor.tlsConfig "context" $ ) | nindent 8 }}
+      {{- end }}
+    relabelings:
+    {{- if .Values.monitor.podMonitor.relabelings }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.monitor.podMonitor.relabelings "context" $) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/risingwave-operator/templates/role.yaml
+++ b/charts/risingwave-operator/templates/role.yaml
@@ -14,9 +14,6 @@ metadata:
   annotations:
     {{ nindent 4 $annotations }}
   {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/charts/risingwave-operator/templates/rolebinding.yaml
+++ b/charts/risingwave-operator/templates/rolebinding.yaml
@@ -14,9 +14,6 @@ metadata:
   annotations:
     {{ nindent 4 $annotations }}
   {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/risingwave-operator/templates/service.yaml
+++ b/charts/risingwave-operator/templates/service.yaml
@@ -14,9 +14,6 @@ metadata:
   annotations:
     {{ nindent 4 $annotations }}
   {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   ports:
   - port: 443

--- a/charts/risingwave-operator/templates/serviceaccount.yaml
+++ b/charts/risingwave-operator/templates/serviceaccount.yaml
@@ -11,11 +11,11 @@ metadata:
   labels:
     {{- include "risingwave-operator.labels" . | nindent 4 }}
   {{- $annotations := (include "risingwave-operator.annotations" . ) | trim }}
-  {{- if $annotations }}
   annotations:
+    {{- if $annotations }}
     {{ nindent 4 $annotations }}
-  {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/risingwave-operator/values.yaml
+++ b/charts/risingwave-operator/values.yaml
@@ -69,7 +69,7 @@ serviceAccount:
 image:
   registry: ghcr.io
   repository: risingwavelabs/risingwave-operator
-  tag: v0.5.6
+  tag: v0.5.7
   digest: ""
   ## @param image.pullPolicy Image pull policy
   ## Specify a imagePullPolicy
@@ -207,9 +207,52 @@ manager:
   shareProcessNamespace: false
 
 proxy:
-  ## @param kube-rbac-proxy.image Image of the kube-rbac-proxy container
+  ## @param proxy.enabled If the kube-rbac-proxy is enabled.
+  ##
+  enabled: false
+  ## @param proxy.image Image of the kube-rbac-proxy container
   ##
   image: quay.io/brancz/kube-rbac-proxy:v0.14.2
-  ## @param kube-rbac-proxy.pullPolicy Image pull policy
+  ## @param proxy.pullPolicy Image pull policy
   ##
   imagePullPolicy: IfNotPresent
+
+## @section Monitor.
+##
+
+monitor:
+  ## Prometheus Pod Monitor
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  podMonitor:
+    ## @param monitor.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param monitor.podMonitor.namespace Namespace in which Prometheus is running
+    ##
+    namespace: monitoring
+    ## @param monitor.podMonitor.interval Specify the interval at which metrics should be scraped
+    ##
+    interval: 5s
+    ## @param monitor.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ##
+    scrapeTimeout: 5s
+    ## @param monitor.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    additionalLabels: { }
+    ## @param monitor.podMonitor.scheme Scheme to use for scraping
+    ##
+    scheme: http
+    ## @param monitor.podMonitor.tlsConfig [object] TLS configuration used for scrape endpoints used by Prometheus
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+    ## e.g:
+    ## tlsConfig:
+    ##   ca:
+    ##     secret:
+    ##       name: existingSecretName
+    ##
+    tlsConfig: { }
+    ## @param monitor.podMonitor.relabelings [array] Prometheus relabeling rules
+    ##
+    relabelings: [ ]

--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.33
+version: 0.1.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1023,30 +1023,30 @@ ports:
 ##
 
 monitor:
-  ## Prometheus Service Monitor
+  ## Prometheus Pod Monitor
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
   ##
   podMonitor:
-    ## @param metrics.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+    ## @param monitor.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
     ##
     enabled: false
-    ## @param metrics.podMonitor.namespace Namespace in which Prometheus is running
+    ## @param monitor.podMonitor.namespace Namespace in which Prometheus is running
     ##
     namespace: monitoring
-    ## @param metrics.podMonitor.interval Specify the interval at which metrics should be scraped
+    ## @param monitor.podMonitor.interval Specify the interval at which metrics should be scraped
     ##
     interval: 5s
-    ## @param metrics.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ## @param monitor.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
     ##
     scrapeTimeout: 5s
-    ## @param metrics.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
+    ## @param monitor.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     ##
     additionalLabels: { }
-    ## @param metrics.podMonitor.scheme Scheme to use for scraping
+    ## @param monitor.podMonitor.scheme Scheme to use for scraping
     ##
     scheme: http
-    ## @param metrics.podMonitor.tlsConfig [object] TLS configuration used for scrape endpoints used by Prometheus
+    ## @param monitor.podMonitor.tlsConfig [object] TLS configuration used for scrape endpoints used by Prometheus
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
     ## e.g:
     ## tlsConfig:
@@ -1055,7 +1055,7 @@ monitor:
     ##       name: existingSecretName
     ##
     tlsConfig: { }
-    ## @param metrics.podMonitor.relabelings [array] Prometheus relabeling rules
+    ## @param monitor.podMonitor.relabelings [array] Prometheus relabeling rules
     ##
     relabelings: [ ]
 


### PR DESCRIPTION
Besides, fix comments and annotations.

1. Use the following values to install a `PodMonitor` while installation.
```yaml
monitor:
  enabled: true
```

2. `kube-rbac-proxy` is disabled by default (breaking change but should affect nothing except monitoring). Enable it with
```yaml
proxy:
  enabled: true
```