### PR TITLE
ci: trigger release only when Chart.yaml changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     paths:
-    - 'charts/**'
+    - 'charts/**/Chart.yaml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
To avoid unnecessary run.