### PR TITLE
fix: skip uploading if tag already exists to avoid failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,7 @@ jobs:
 
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@v1.6.0
+      with:
+        skip_existing: true
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
To fix https://github.com/risingwavelabs/helm-charts/actions/runs/8186625154

Reference: https://github.com/helm/chart-releaser-action

I'll need to manually trigger it once after this is merged.