### PR TITLE
feat: optional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,28 @@ You can then run `helm search repo risingwavelabs` to see the charts.
 
 ## Deploy
 
+[//]: # (https://github.com/orgs/community/discussions/16925)
+> [!NOTE]
+>
+> The value `tags.bundle=true` tells Helm to use the sub-charts
+> [bitnami/etcd](https://artifacthub.io/packages/helm/bitnami/etcd) and
+> [bitnami/minio](https://artifacthub.io/packages/helm/bitnami/minio) to provide the persistency services
+> for RisingWave to store both metadata and stream states.
+>
+> If you would like to enable/disable them individually, try setting the values
+> `tags.etcd` and `tags.minio`. Make sure that `tags.bundle=false` when you would like to have such control.
+
 To deploy the RisingWave chart with the release name `risingwave`:
 
 ```bash
-helm install --set wait=true risingwave risingwavelabs/risingwave
+helm install --set wait=true,tags.bundle=true risingwave risingwavelabs/risingwave
 ```
+
+> [!TIP]
+>
+> If the bundled etcd and MinIO don't suit your requirements well, just remove the `tags.bundle` and
+> set the stores accordingly. The options are under `metaStore` and `stateStore`. You can check all the possible values
+> with `helm show values risingwavelabs/risingwave`.
 
 Example output:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ helm install --set wait=true,tags.bundle=true risingwave risingwavelabs/risingwa
 >
 > If the bundled etcd and MinIO don't suit your requirements well, just remove the `tags.bundle` and
 > set the stores accordingly. The options are under `metaStore` and `stateStore`. You can check all the possible values
-> with `helm show values risingwavelabs/risingwave`.
+> with `helm show values risingwavelabs/risingwave`. Here are some examples for both [meta store](examples/meta-stores)
+> and [state store](examples/state-stores).
 
 Example output:
 

--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -28,17 +28,21 @@ version: 0.1.44
 appVersion: v1.7.0
 
 dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.x.x
 - name: etcd
-  version: "~9.14.3"
+  version: 9.x.x
   repository: https://charts.bitnami.com/bitnami
   tags:
   - etcd
+  - bundle
 - name: minio
-  version: "~13.7.0"
+  version: 13.x.x
   repository: https://charts.bitnami.com/bitnami
-  condition: stateStore.minio.enabled
   tags:
   - minio
+  - bundle
 
 home: https://www.risingwave.com
 icon: https://avatars.githubusercontent.com/u/77175557?s=48&v=4

--- a/charts/risingwave/templates/compactor-deploy.yaml
+++ b/charts/risingwave/templates/compactor-deploy.yaml
@@ -167,7 +167,7 @@ spec:
         - name: OBS_REGION
           value: {{ .Values.stateStore.obs.region }}
         {{- end }}
-        {{- if and .Values.tags.minio .Values.stateStore.minio.enabled }}
+        {{- if (include "risingwave.bundle.minio.enabled" .) }}
         - name: MINIO_USERNAME
           valueFrom:
             secretKeyRef:

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -171,7 +171,7 @@ spec:
         - name: OBS_REGION
           value: {{ .Values.stateStore.obs.region }}
         {{- end }}
-        {{- if and .Values.tags.minio .Values.stateStore.minio.enabled }}
+        {{- if (include "risingwave.bundle.minio.enabled" .) }}
         - name: MINIO_USERNAME
           valueFrom:
             secretKeyRef:

--- a/charts/risingwave/templates/etcd-secret.yaml
+++ b/charts/risingwave/templates/etcd-secret.yaml
@@ -3,7 +3,7 @@ Copyright RisingWave Labs
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (not .Values.tags.etcd) .Values.metaStore.etcd.authentication.enabled }}
+{{- if and (not (include "risingwave.bundle.etcd.enabled" .)) .Values.metaStore.etcd.authentication.enabled }}
 {{- if not .Values.metaStore.etcd.authentication.existingSecretName }}
 apiVersion: v1
 kind: Secret

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -178,7 +178,7 @@ spec:
         - name: OBS_REGION
           value: {{ .Values.stateStore.obs.region }}
         {{- end }}
-        {{- if and .Values.tags.minio .Values.stateStore.minio.enabled }}
+        {{- if (include "risingwave.bundle.minio.enabled" .) }}
         - name: MINIO_USERNAME
           valueFrom:
             secretKeyRef:
@@ -229,7 +229,7 @@ spec:
           value: {{ include "risingwave.metaStoreEtcdEndpoints" . }}
         - name: RW_ETCD_AUTH
           value: {{ include "risingwave.metaStoreAuthRequired" . | quote }}
-        {{- if .Values.tags.etcd }}
+        {{- if (include "risingwave.bundle.etcd.enabled" .) }}
         {{- if .Values.etcd.auth.rbac.create }}
         - name: RW_ETCD_USERNAME
           value: root

--- a/charts/risingwave/templates/minio-secret.yaml
+++ b/charts/risingwave/templates/minio-secret.yaml
@@ -3,7 +3,7 @@ Copyright RisingWave Labs
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (not .Values.tags.minio) .Values.stateStore.minio.enabled }}
+{{- if and (not (include "risingwave.bundle.minio.enabled" .)) .Values.stateStore.minio.enabled }}
 {{- if empty .Values.stateStore.minio.authentication.existingSecretName }}
 apiVersion: v1
 kind: Secret

--- a/charts/risingwave/templates/standalone/standalone-sts.yaml
+++ b/charts/risingwave/templates/standalone/standalone-sts.yaml
@@ -116,7 +116,7 @@ spec:
             --state-store $(RW_STATE_STORE)
             --data-directory $(RW_DATA_DIRECTORY)
             --config-path /risingwave/config/risingwave.toml
-        {{- if .Values.tags.etcd }}
+        {{- if (include "risingwave.bundle.etcd.enabled" .) }}
         {{- if and (not .Values.etcd.auth.rbac.allowNoneAuthentication) .Values.etcd.auth.rbac.create }}
             --etcd-auth
             --etcd-username $(RW_ETCD_USERNAME)
@@ -232,7 +232,7 @@ spec:
         - name: OBS_REGION
           value: {{ .Values.stateStore.obs.region }}
         {{- end }}
-        {{- if and .Values.tags.minio .Values.stateStore.minio.enabled }}
+        {{- if (include "risingwave.bundle.minio.enabled" .) }}
         - name: MINIO_USERNAME
           valueFrom:
             secretKeyRef:
@@ -279,7 +279,7 @@ spec:
           value: {{ include "risingwave.metaStoreEtcdEndpoints" . }}
         - name: RW_ETCD_AUTH
           value: {{ include "risingwave.metaStoreAuthRequired" . | quote }}
-        {{- if .Values.tags.etcd }}
+        {{- if (include "risingwave.bundle.etcd.enabled" .) }}
         {{- if .Values.etcd.auth.rbac.create }}
         - name: RW_ETCD_USERNAME
           value: root

--- a/charts/risingwave/templates/validation.yaml
+++ b/charts/risingwave/templates/validation.yaml
@@ -7,171 +7,211 @@ SPDX-License-Identifier: APACHE-2.0
 Validate state store backends.
 */}}
 {{- $count := 0 -}}
+{{- $name := "" }}
+# Count without MinIO.
 {{- with .Values.stateStore }}
-{{- if .s3.enabled }}{{ $count = add1 $count }}{{- end }}
-{{- if .minio.enabled }}{{ $count = add1 $count }}{{- end }}
-{{- if .gcs.enabled }}{{ $count = add1 $count }}{{- end }}
-{{- if .oss.enabled }}{{ $count = add1 $count }}{{- end }}
-{{- if .azblob.enabled }}{{ $count = add1 $count }}{{- end }}
-{{- if .hdfs.enabled }}{{ $count = add1 $count }}{{- end }}
-{{- if .obs.enabled}}{{ $count = add1 $count }}{{- end }}
-{{- if (eq $count 0 ) }}
-{{- fail "No state store backend is enabled, required one"}}
-{{- else if (gt $count 1) }}
-{{- fail "Multiple state store backends are enabled, only one is allowed"}}
+  {{- if .s3.enabled }}{{ $count = add1 $count }}{{ $name = "S3" }}{{- end }}
+  {{- if .gcs.enabled }}{{ $count = add1 $count }}{{ $name = "GCS" }}{{- end }}
+  {{- if .oss.enabled }}{{ $count = add1 $count }}{{ $name = "OSS" }}{{- end }}
+  {{- if .azblob.enabled }}{{ $count = add1 $count }}{{ $name = "AZBLOB" }}{{- end }}
+  {{- if .hdfs.enabled }}{{ $count = add1 $count }}{{ $name = "HDFS" }}{{- end }}
+  {{- if .obs.enabled}}{{ $count = add1 $count }}{{ $name = "OBS" }}{{- end }}
 {{- end }}
+# If there's no state store and bundled minio enabled, count = 1
+{{- if (include "risingwave.bundle.minio.enabled" .) }}
+  {{- if and (eq $count 0) }}
+    {{ $count = add1 $count }}
+    {{ $name = "MinIO" }}
+  {{- else }}
+    {{- fail "Unnecessary bundled minio when $name is enabled! Try setting `tags.minio=false,tags.bundle=false` and retry!"}}
+  {{- end }}
+{{- else }}
+  {{- if .Values.stateStore.oss.enabled }}{{ $count = add1 $count }}{{ $name = "MinIO" }}{{- end }}
+{{- end }}
+{{- if (eq $count 0 ) }}
+  {{- fail "No state store backend!\n  Please set up one of S3, MinIO, GCS, OSS, AZBLOB, HDFS, and OBS under `stateStore`, or use the bundled MinIO by setting `tags.minio=true`!"}}
+{{- else if (gt $count 1) }}
+  {{- fail "More than one state store backend!"}}
 {{- end }}
 
 {{/*
 Validate the embedded MinIO.
 */}}
-{{- if and .Values.tags.minio .Values.stateStore.minio.enabled }}
-{{- if empty .Values.minio.defaultBuckets }}
-{{- fail "Create at least one default bucket in MinIO to use" }}
+{{- if (include "risingwave.bundle.minio.enabled" .) }}
+  {{- if empty .Values.minio.defaultBuckets }}
+    {{- fail "Set at least one bucket in `minio.defaultBuckets`!" }}
+  {{- end }}
 {{- end }}
+
+{{/*
+Validate meta store backends.
+*/}}
+{{- $count = 0 -}}
+{{- $name = "" }}
+# Count without etcd.
+{{- with .Values.metaStore }}
+{{/*  {{- if .etcd.enabled }}{{ $count = add1 $count }}{{ $name = "etcd" }}{{- end }}*/}}
+{{- end }}
+# If there's no state store and bundled minio enabled, count = 1
+{{- if (include "risingwave.bundle.etcd.enabled" .) }}
+  {{- if and (eq $count 0) }}
+    {{ $count = add1 $count }}
+    {{ $name = "etcd" }}
+  {{- else }}
+    {{- fail "Unnecessary bundled etcd when $name is enabled!"}}
+  {{- end }}
+{{- else }}
+  {{- if .Values.metaStore.etcd.enabled }}{{ $count = add1 $count }}{{ $name = "etcd" }}{{- end }}
+{{- end }}
+{{- if (eq $count 0 ) }}
+  {{- fail "No meta store backend!\n  Please set up an external etcd under `metaStore`, or use the bundled one by setting `tags.etcd=true`!"}}
+{{- else if (gt $count 1) }}
+  {{- fail "More than one meta store backend!"}}
 {{- end }}
 
 {{/*
 Validate parameters of etcd meta store.
 */}}
-{{- if not .Values.tags.etcd }}
-{{- if empty .Values.metaStore.etcd.endpoints }}
-{{- fail "Meta store etcd endpoints must be set" }}
-{{- end }}
-{{- if .Values.metaStore.etcd.authentication.enabled }}
-{{- if empty .Values.metaStore.etcd.authentication.username }}
-{{- fail "Meta store etcd authentication is enabled, username must be set" }}
-{{- end }}
-{{- if empty .Values.metaStore.etcd.authentication.password }}
-{{- fail "Meta store etcd authentication is enabled, password must be set" }}
-{{- end }}
-{{- end }}
+{{- if not (include "risingwave.bundle.etcd.enabled" .) }}
+  {{- if .Values.metaStore.etcd.enabled }}
+    {{- if empty .Values.metaStore.etcd.endpoints }}
+      {{- fail "Meta store etcd endpoints must be set" }}
+    {{- end }}
+    {{- if .Values.metaStore.etcd.authentication.enabled }}
+      {{- if empty .Values.metaStore.etcd.authentication.username }}
+        {{- fail "Meta store etcd authentication is enabled, username must be set" }}
+      {{- end }}
+      {{- if empty .Values.metaStore.etcd.authentication.password }}
+        {{- fail "Meta store etcd authentication is enabled, password must be set" }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Validate parameters of S3 state store.
 */}}
 {{- with .Values.stateStore.s3 }}
-{{- if .enabled }}
-{{- if empty .bucket }}
-{{- fail "State store S3 bucket must be set" }}
-{{- end }}
-{{- if empty .region }}
-{{- fail "State store S3 region must be set" }}
-{{- end }}
-{{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
-{{- if empty .authentication.accessKey }}
-{{- fail "State store S3 authentication access key must be set" }}
-{{- end }}
-{{- if empty .authentication.secretAccessKey }}
-{{- fail "State store S3 authentication secret access key must be set" }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- if .enabled }}
+    {{- if empty .bucket }}
+      {{- fail "State store S3 bucket must be set" }}
+    {{- end }}
+    {{- if empty .region }}
+      {{- fail "State store S3 region must be set" }}
+    {{- end }}
+    {{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
+      {{- if empty .authentication.accessKey }}
+        {{- fail "State store S3 authentication access key must be set" }}
+      {{- end }}
+      {{- if empty .authentication.secretAccessKey }}
+        {{- fail "State store S3 authentication secret access key must be set" }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Validate parameters of external MinIO state store.
 */}}
-{{- if not .Values.tags.minio }}
-{{- with .Values.stateStore.minio }}
-{{- if .enabled }}
-{{- if empty .endpoint }}
-{{- fail "State store MinIO endpoint must be set" }}
-{{- end }}
-{{- if empty .bucket }}
-{{- fail "State store MinIO bucket must be set" }}
-{{- end }}
-{{- if empty .authentication.existingSecretName }}
-{{- if empty .authentication.username }}
-{{- fail "State store MinIO authentication username must be set" }}
-{{- end }}
-{{- if empty .authentication.password }}
-{{- fail "State store MinIO authentication password key must be set" }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- if not (include "risingwave.bundle.minio.enabled" .) }}
+  {{- with .Values.stateStore.minio }}
+    {{- if .enabled }}
+      {{- if empty .endpoint }}
+        {{- fail "State store MinIO endpoint must be set" }}
+      {{- end }}
+      {{- if empty .bucket }}
+        {{- fail "State store MinIO bucket must be set" }}
+      {{- end }}
+      {{- if empty .authentication.existingSecretName }}
+        {{- if empty .authentication.username }}
+          {{- fail "State store MinIO authentication username must be set" }}
+        {{- end }}
+        {{- if empty .authentication.password }}
+          {{- fail "State store MinIO authentication password key must be set" }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Validate parameter of GCS state store.
 */}}
 {{- with .Values.stateStore.gcs }}
-{{- if .enabled }}
-{{- if empty .bucket }}
-{{- fail "State store GCS bucket must be set" }}
-{{- end }}
-{{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
-{{- if empty .authentication.credentials }}
-{{- fail "State store GCS authentication credentials must be set" }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- if .enabled }}
+    {{- if empty .bucket }}
+      {{- fail "State store GCS bucket must be set" }}
+    {{- end }}
+    {{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
+      {{- if empty .authentication.credentials }}
+        {{- fail "State store GCS authentication credentials must be set" }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Validate parameters of OSS state store.
 */}}
 {{- with .Values.stateStore.oss }}
-{{- if .enabled }}
-{{- if empty .bucket }}
-{{- fail "State store OSS bucket must be set" }}
-{{- end }}
-{{- if empty .region }}
-{{- fail "State store OSS region must be set" }}
-{{- end }}
-{{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
-{{- if empty .authentication.accessKey }}
-{{- fail "State store OSS authentication access key must be set" }}
-{{- end }}
-{{- if empty .authentication.secretAccessKey }}
-{{- fail "State store OSS authentication secret access key must be set" }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- if .enabled }}
+    {{- if empty .bucket }}
+      {{- fail "State store OSS bucket must be set" }}
+    {{- end }}
+    {{- if empty .region }}
+      {{- fail "State store OSS region must be set" }}
+    {{- end }}
+    {{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
+      {{- if empty .authentication.accessKey }}
+        {{- fail "State store OSS authentication access key must be set" }}
+      {{- end }}
+      {{- if empty .authentication.secretAccessKey }}
+        {{- fail "State store OSS authentication secret access key must be set" }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Validate parameters of OBS state store.
 */}}
 {{- with .Values.stateStore.obs }}
-{{- if .enabled }}
-{{- if empty .bucket }}
-{{- fail "State store OBS bucket must be set" }}
-{{- end }}
-{{- if empty .region }}
-{{- fail "State store OBS region must be set" }}
-{{- end }}
-{{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
-{{- if empty .authentication.accessKey }}
-{{- fail "State store OBS authentication access key must be set" }}
-{{- end }}
-{{- if empty .authentication.secretAccessKey }}
-{{- fail "State store OBS authentication secret access key must be set" }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- if .enabled }}
+    {{- if empty .bucket }}
+      {{- fail "State store OBS bucket must be set" }}
+    {{- end }}
+    {{- if empty .region }}
+      {{- fail "State store OBS region must be set" }}
+    {{- end }}
+    {{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
+      {{- if empty .authentication.accessKey }}
+        {{- fail "State store OBS authentication access key must be set" }}
+      {{- end }}
+      {{- if empty .authentication.secretAccessKey }}
+        {{- fail "State store OBS authentication secret access key must be set" }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Validate parameters of AzureBlob state store.
 */}}
 {{- with .Values.stateStore.azblob }}
-{{- if .enabled }}
-{{- if empty .endpoint }}
-{{- fail "State store AzureBlob endpoint must be set" }}
-{{- end }}
-{{- if empty .container }}
-{{- fail "State store AzureBlob container must be set" }}
-{{- end }}
-{{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
-{{- if empty .authentication.accountKey }}
-{{- fail "State store AzureBlob authentication account key must be set" }}
-{{- end }}
-{{- if empty .authentication.accountName }}
-{{- fail "State store AzureBlob authentication account name must be set" }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- if .enabled }}
+    {{- if empty .endpoint }}
+      {{- fail "State store AzureBlob endpoint must be set" }}
+    {{- end }}
+    {{- if empty .container }}
+      {{- fail "State store AzureBlob container must be set" }}
+    {{- end }}
+    {{- if and (empty .authentication.existingSecretName) (not .authentication.useServiceAccount) }}
+      {{- if empty .authentication.accountKey }}
+        {{- fail "State store AzureBlob authentication account key must be set" }}
+      {{- end }}
+      {{- if empty .authentication.accountName }}
+        {{- fail "State store AzureBlob authentication account name must be set" }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/risingwave/tests/etcd_secret_test.yaml
+++ b/charts/risingwave/tests/etcd_secret_test.yaml
@@ -5,7 +5,16 @@ chart:
   appVersion: 1.0.0
   version: 0.0.1
 tests:
-- it: bundled etcd should not render secret
+- it: bundled etcd should not render secret .tags.bundle
+  set:
+    tags.bundle: true
+    metaStore.etcd.authentication:
+      enabled: true
+      existingSecretName: EXISTING_SECRET_NAME
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: bundled etcd should not render secret .tags.etcd
   set:
     tags.etcd: true
     metaStore.etcd.authentication:

--- a/charts/risingwave/tests/minio_secret_test.yaml
+++ b/charts/risingwave/tests/minio_secret_test.yaml
@@ -22,6 +22,15 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
+- it: bundled minio should not render secret
+  set:
+    tags.bundle: true
+    stateStore:
+      minio:
+        enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
 - it: external minio authenticating with existing secret should not render secret
   set:
     tags.minio: false

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -5,16 +5,22 @@
 ## Ref: https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies
 ##
 tags:
+  ## @param tags.bundle Tag to control all bundled dependencies, including bitnami/etcd
+  ## and bitnami/minio. Please refer to tags.etcd and tags.minio for more details.
+  ## @values true, false
+  ##
+  bundle: false
+
   ## @param tags.etcd Tag to control the bitnami/etcd dependency.
   ## @values true,false
   ##
-  etcd: true
+  etcd: false
 
   ## @param tags.minio Tag to control the bitnami/minio dependency.
   ## @values true,false
   ## Note that even if it is true, when the state store isn't minio, it won't be installed.
   ##
-  minio: true
+  minio: false
 
 ## @section Values for the bitnami/etcd dependency.
 ## Ref: https://github.com/bitnami/charts/blob/main/bitnami/etcd/values.yaml
@@ -327,6 +333,10 @@ metaStore:
   ## @section metaStore.etcd only takes effect when tags.etcd is false.
   ##
   etcd:
+    ## @param metaStore.etcd.enabled Enable/disable the meta store backend.
+    ##
+    enabled: false
+
     ## @param metaStore.etcd.endpoints [array] Etcd endpoints
     ##
     endpoints: [ ]
@@ -401,7 +411,7 @@ stateStore:
   minio:
     ## @param stateStore.minio.enabled Use MinIO state store. Only one state store backend can be enabled.
     ##
-    enabled: true
+    enabled: false
     ## @param stateStore.minio.endpoint MinIO endpoint.
     ##
     endpoint: ""

--- a/examples/meta-stores/external-etcd.values.yaml
+++ b/examples/meta-stores/external-etcd.values.yaml
@@ -1,12 +1,9 @@
-tags:
-  etcd: false
-
 metaStore:
   etcd:
+    enabled: true
     endpoints:
     - etcd:2379
-
-  authentication:
-    enabled: true
-    username: "root"
-    password: "123456"
+    authentication:
+      enabled: true
+      username: "root"
+      password: "123456"

--- a/examples/state-stores/azblob.values.yaml
+++ b/examples/state-stores/azblob.values.yaml
@@ -1,10 +1,5 @@
-tags:
-  minio: false
-
 stateStore:
-  minio:
-    enabled: false
-
+  dataDirectory: "prefix/of/data"
   azblob:
     enabled: true
     endpoint: https://your-azure-account-name.blob.core.windows.net

--- a/examples/state-stores/customize-data-directory.values.yaml
+++ b/examples/state-stores/customize-data-directory.values.yaml
@@ -1,2 +1,0 @@
-stateStore:
-  dataDirectory: "my/hummock"

--- a/examples/state-stores/eks-s3-iam.values.yaml
+++ b/examples/state-stores/eks-s3-iam.values.yaml
@@ -1,15 +1,10 @@
-tags:
-  minio: false
-
 serviceAccount:
   create: true
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/my-role
 
 stateStore:
-  minio:
-    enabled: false
-
+  dataDirectory: "prefix/of/data"
   s3:
     enabled: true
     region: us-east-1

--- a/examples/state-stores/external-minio.values.yaml
+++ b/examples/state-stores/external-minio.values.yaml
@@ -1,7 +1,5 @@
-tags:
-  minio: false
-
 stateStore:
+  dataDirectory: "prefix/of/data"
   minio:
     enabled: true
     endpoint: minio:9000

--- a/examples/state-stores/gcs.values.yaml
+++ b/examples/state-stores/gcs.values.yaml
@@ -1,10 +1,5 @@
-tags:
-  minio: false
-
 stateStore:
-  minio:
-    enabled: false
-
+  dataDirectory: "prefix/of/data"
   gcs:
     enabled: true
     bucket: risingwave

--- a/examples/state-stores/hdfs.values.yaml
+++ b/examples/state-stores/hdfs.values.yaml
@@ -1,10 +1,5 @@
-tags:
-  minio: false
-
 stateStore:
-  minio:
-    enabled: false
-
+  dataDirectory: "prefix/of/data"
   hdfs:
     enabled: true
     nameNode: hadoop-hdfs-master:9000

--- a/examples/state-stores/obs.values.yaml
+++ b/examples/state-stores/obs.values.yaml
@@ -1,6 +1,6 @@
 stateStore:
   dataDirectory: "prefix/of/data"
-  s3:
+  obs:
     enabled: true
     region: us-east-1
     bucket: risingwave

--- a/examples/state-stores/oss.values.yaml
+++ b/examples/state-stores/oss.values.yaml
@@ -1,10 +1,5 @@
-tags:
-  minio: false
-
 stateStore:
-  minio:
-    enabled: false
-
+  dataDirectory: "prefix/of/data"
   oss:
     enabled: true
     region: cn-hangzhou

--- a/examples/state-stores/s3-compatible.values.yaml
+++ b/examples/state-stores/s3-compatible.values.yaml
@@ -1,10 +1,5 @@
-tags:
-  minio: false
-
 stateStore:
-  minio:
-    enabled: false
-
+  dataDirectory: "prefix/of/data"
   s3:
     enabled: true
     endpoint: s3-compatible-service-domain:9000


### PR DESCRIPTION
This is a breaking change that
- Turns off `tags.etcd` and `tags.minio` by default.
- Add a new tag `tags.bundle` to enable all the bundled sub-charts.

However it still maintains the semantics compatible. That means by explicitly providing the tags one can migrate from the old charts.

It also addressed an issue when `etcd` and `minio` are both disabled by explicitly include the `bitnami/common`.

