### PR TITLE
feat: add pre-stop hook to unregister a compute node before its pod's termination

### DIFF
--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -123,6 +123,7 @@ spec:
         command:
         - /risingwave/bin/risingwave
         - compute-node
+        {{- if .Values.computeComponent.autoDeregistration.enabled }}
         lifecycle:
           preStop:
             exec:
@@ -132,6 +133,7 @@ spec:
               - >-
                 /risingwave/bin/risingwave ctl meta unregister-workers --yes \
                   --workers ${POD_NAME}.{{ include "risingwave.computeHeadlessServiceName" . }}.{{.Release.Namespace}}.svc:{{ .Values.ports.compute.svc }}
+        {{- end }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.ports.compute.svc }}

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -123,6 +123,15 @@ spec:
         command:
         - /risingwave/bin/risingwave
         - compute-node
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - bash
+              - -c
+              - >-
+                /risingwave/bin/risingwave ctl meta unregister-workers --yes \
+                  --workers ${POD_NAME}.{{ include "risingwave.computeHeadlessServiceName" . }}.{{.Release.Namespace}}.svc:{{ .Values.ports.compute.svc }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.ports.compute.svc }}

--- a/charts/risingwave/tests/compute_auto_deregistration_test.yaml
+++ b/charts/risingwave/tests/compute_auto_deregistration_test.yaml
@@ -1,0 +1,31 @@
+suite: Test compute auto deregistration
+templates:
+- compute-sts.yaml
+chart:
+  appVersion: 1.0.0
+  version: 0.0.1
+tests:
+- it: lifecycle doesn't exist when disabled
+  set:
+    computeComponent:
+      autoDeregistration:
+        enabled: false
+  asserts:
+  - notExists:
+      path: spec.template.spec.containers[0].lifecycle
+- it: lifecycle exists when enabled
+  set:
+    computeComponent:
+      autoDeregistration:
+          enabled: true
+  asserts:
+  - exists:
+      path: spec.template.spec.containers[0].lifecycle
+  - equal:
+      path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+      value:
+      - bash
+      - -c
+      - >-
+        /risingwave/bin/risingwave ctl meta unregister-workers --yes \
+          --workers ${POD_NAME}.RELEASE-NAME-risingwave-compute-headless.NAMESPACE.svc:5688

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1061,6 +1061,13 @@ computeComponent:
     whenDeleted: Delete
     whenScaled: Delete
 
+  ## @param autoDeregistration Auto-deregistration of compute pods. If enabled, compute pods will be
+  ## automatically deregistered from the meta store when they are deleted.
+  ##
+  autoDeregistration:
+    ## @param autoDeregistration.enabled Enable auto-deregistration.
+    enabled: false
+
 compactorComponent:
   ## @param compactorComponent.podLabels Labels to add to the component pods.
   ##


### PR DESCRIPTION
In addition,
- set the default `terminationGracePeriodSeconds` of compute pods to 10s to give the hook some time,
- bump the RisingWave to v1.8.0.