### PR TITLE
chore: bump risingwave-operator to v0.6.3

### DIFF
--- a/charts/risingwave-operator/Chart.yaml
+++ b/charts/risingwave-operator/Chart.yaml
@@ -7,13 +7,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.2"
+appVersion: v0.6.3
 
 home: https://www.risingwave.com
 icon: https://avatars.githubusercontent.com/u/77175557?s=48&v=4

--- a/charts/risingwave-operator/crds/risingwave-operator.crds.yaml
+++ b/charts/risingwave-operator/crds/risingwave-operator.crds.yaml
@@ -28853,7 +28853,7 @@ spec:
                   But keep in mind that memory backend is not recommended in production.
                 properties:
                   etcd:
-                    description: Endpoint of the etcd service for storing the metadata.
+                    description: Stores metadata in etcd.
                     properties:
                       credentials:
                         description: |-
@@ -28900,6 +28900,114 @@ spec:
                       replicas will not work because they are not going to share the same metadata and any kinds
                       exit of the process will cause a permanent loss of the data.
                     type: boolean
+                  mysql:
+                    description: MySQL stores metadata in a MySQL DB.
+                    properties:
+                      credentials:
+                        description: |-
+                          RisingWaveDBCredentials is the reference credentials. User must provide a secret contains
+                          `username` and `password` (or one can customize the key references) keys and the correct values.
+                        properties:
+                          passwordKeyRef:
+                            default: password
+                            description: |-
+                              PasswordKeyRef is the key of the secret to be the password. Must be a valid secret key.
+                              Defaults to "password".
+                            type: string
+                          secretName:
+                            description: The name of the secret in the pod's namespace
+                              to select from.
+                            type: string
+                          usernameKeyRef:
+                            default: username
+                            description: |-
+                              UsernameKeyRef is the key of the secret to be the username. Must be a valid secret key.
+                              Defaults to "username".
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      database:
+                        description: Database of the MySQL DB.
+                        type: string
+                      host:
+                        description: Host of the MySQL DB.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: Options when connecting to the MySQL DB. Optional.
+                        type: object
+                      port:
+                        default: 3306
+                        description: Port of the MySQL DB. Defaults to 3306.
+                        format: int32
+                        type: integer
+                    required:
+                    - credentials
+                    - database
+                    - host
+                    - port
+                    type: object
+                  postgresql:
+                    description: PostgreSQL stores metadata in a PostgreSQL DB.
+                    properties:
+                      credentials:
+                        description: |-
+                          RisingWaveDBCredentials is the reference credentials. User must provide a secret contains
+                          `username` and `password` (or one can customize the key references) keys and the correct values.
+                        properties:
+                          passwordKeyRef:
+                            default: password
+                            description: |-
+                              PasswordKeyRef is the key of the secret to be the password. Must be a valid secret key.
+                              Defaults to "password".
+                            type: string
+                          secretName:
+                            description: The name of the secret in the pod's namespace
+                              to select from.
+                            type: string
+                          usernameKeyRef:
+                            default: username
+                            description: |-
+                              UsernameKeyRef is the key of the secret to be the username. Must be a valid secret key.
+                              Defaults to "username".
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      database:
+                        description: Database of the PostgreSQL DB.
+                        type: string
+                      host:
+                        description: Host of the PostgreSQL DB.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: Options when connecting to the PostgreSQL DB.
+                          Optional.
+                        type: object
+                      port:
+                        default: 5432
+                        description: Port of the PostgreSQL DB. Defaults to 5432.
+                        format: int32
+                        type: integer
+                    required:
+                    - credentials
+                    - database
+                    - host
+                    - port
+                    type: object
+                  sqlite:
+                    description: SQLite stores metadata in a SQLite DB file.
+                    properties:
+                      path:
+                        description: Path of the DB file.
+                        type: string
+                    required:
+                    - path
+                    type: object
                 type: object
               stateStore:
                 default:
@@ -28979,8 +29087,11 @@ spec:
                             description: The name of the secret in the pod's namespace
                               to select from.
                             type: string
-                        required:
-                        - secretName
+                          useServiceAccount:
+                            description: |-
+                              UseServiceAccount indicates whether to use the service account token mounted in the pod.
+                              If this is enabled, secret and keys are ignored. Defaults to false.
+                            type: boolean
                         type: object
                       endpoint:
                         description: |-

--- a/charts/risingwave-operator/values.yaml
+++ b/charts/risingwave-operator/values.yaml
@@ -61,7 +61,7 @@ serviceAccount:
 image:
   registry: ghcr.io
   repository: risingwavelabs/risingwave-operator
-  tag: v0.6.2
+  tag: v0.6.3
   digest: ""
   ## @param image.pullPolicy Image pull policy
   ## Specify a imagePullPolicy


### PR DESCRIPTION
CRDs have been updated. Upgrading a release won't touch CRDs according to Helm's convention. One must execute the following command manually to update:

```kubectl
kubectl apply --server-side -f https://raw.githubusercontent.com/risingwavelabs/helm-charts/risingwave-operator-0.1.14/charts/risingwave-operator/crds/risingwave-operator.crds.yaml
```