### PR TITLE
Revert "chore: bump risingwave to v1.9.0, release chart 0.1.59"

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.58
+version: 0.1.60
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,13 +19,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.59
+version: 0.1.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.9.0"
+appVersion: "v1.8.2"
 
 dependencies:
 - name: common

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -128,7 +128,7 @@ diagnosticMode:
 image:
   registry:
   repository: risingwavelabs/risingwave
-  tag: "v1.9.0"
+  tag: "v1.8.2"
   digest: ""
   ## @param image.pullPolicy RisingWave image pull policy
   ## Specify a imagePullPolicy


### PR DESCRIPTION
Reverts risingwavelabs/helm-charts#87

For the same reason as https://github.com/risingwavelabs/risingwave-operator/pull/658. The version's bumped because it's non-trivial to revoke a release with helm.