### PR TITLE
feat: utilize Scarf Gateway endpoint for RisingWave image and operator helm charts

### DIFF
--- a/charts/risingwave-operator/values.yaml
+++ b/charts/risingwave-operator/values.yaml
@@ -59,7 +59,7 @@ serviceAccount:
 ## @param image.digest Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ##
 image:
-  registry: ghcr.io
+  registry: risingwave.docker.scarf.sh
   repository: risingwavelabs/risingwave-operator
   tag: v0.7.0
   digest: ""

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -126,7 +126,7 @@ diagnosticMode:
 ## @param image.digest RisingWave image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ##
 image:
-  registry:
+  registry: risingwave.docker.scarf.sh
   repository: risingwavelabs/risingwave
   tag: "v1.8.2"
   digest: ""


### PR DESCRIPTION
This PR updates the RisingWave configuration for helm charts to fetch the RisingWave main container image as well as the RisingWave operator container image via a Scarf endpoint. This allows RisingWave maintainers to collect basic de-identified download and adoption metrics. It does not affect where the containers are being hosted, as Scarf is only redirecting traffic back to GHCR. 

This change was suggested by the RisingWave product team in direct discussions. To test this, download RisingWave using the new endpoint (e.g. docker pull risingwave.docker.scarf.sh/risingwavelabs/risingwave) and verify that the risingwavelabs/risingwave container downloads without issue.