### PR TITLE
 feat: utilize Scarf Gateway endpoint for RisingWave image and operator helm charts

### DIFF
--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -126,7 +126,7 @@ diagnosticMode:
 ## @param image.digest RisingWave image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ##
 image:
-  registry:
+  registry: docker.risingwave.com
   repository: risingwavelabs/risingwave
   tag: "v1.8.2"
   digest: ""


### PR DESCRIPTION
This PR updates the RisingWave configuration for helm charts to fetch the RisingWave main container image as well as the RisingWave operator container image via a Scarf endpoint. This allows RisingWave maintainers to collect basic de-identified download and adoption metrics. It does not affect where the containers are being hosted, as Scarf is only redirecting traffic back to GHCR.

<img width="1088" alt="image" src="https://github.com/risingwavelabs/helm-charts/assets/19244687/b654804c-a546-42d8-a99d-6644cb151f0b">
