### PR TITLE
fix: remove `currentSchema` options from postgres meta store example

### DIFF
--- a/examples/meta-stores/postgresql.values.yaml
+++ b/examples/meta-stores/postgresql.values.yaml
@@ -4,8 +4,6 @@ metaStore:
     host: postgresql.example
     port: 5432
     database: risingwave
-    options:
-      currentSchema: my_schema
     authentication:
       username: "root"
       password: "123456"


### PR DESCRIPTION
Resolve #96.