### PR TITLE
feat: support existing secret name in auth

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.63
+version: 0.1.64
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/NOTES.txt
+++ b/charts/risingwave/templates/NOTES.txt
@@ -30,8 +30,11 @@ Try accessing the SQL console with the following command:
 
 Keep the above command running and open a new terminal window to run the following command:
 {{ end }}
-    {{- if .Values.auth.rootPassword }}
+    {{- if and (not .Values.auth.existingSecretName) .Values.auth.rootPassword }}
     export PGPASSWORD=$({{ $kubectlArgs }} get secret {{ include "risingwave.fullname" . }} -o jsonpath="{.data.root-password}" | base64 --decode)
+    {{- end }}
+    {{- if .Values.auth.existingSecretName }}
+    export PGPASSWORD=$({{ $kubectlArgs }} get secret {{ .Values.auth.existingSecretName }} -o jsonpath="{.data.root-password}" | base64 --decode)
     {{- end }}
     {{- if eq .Values.service.type "LoadBalancer" }}
     export PGHOST=$({{ $kubectlArgs }} get svc risingwave -o jsonpath="{.status.loadBalancer.ingress[0].ip} {.status.loadBalancer.ingress[0].hostname}"| awk '{print $1;}')

--- a/charts/risingwave/templates/hooks/post-install-create-root-user.yaml
+++ b/charts/risingwave/templates/hooks/post-install-create-root-user.yaml
@@ -36,11 +36,19 @@ spec:
             secretKeyRef:
               name: {{ include "risingwave.fullname" . }}
               key: root-user
+        {{- if not .Values.auth.existingSecretName }}
         - name: PG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "risingwave.fullname" . }}
               key: root-password
+        {{- else }}
+        - name: PG_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.existingSecretName }}
+              key: root-password
+        {{- end }}
         {{- if ne .Values.auth.rootUser "root" }}
         - name: PG_REAL_ROOT_PASSWORD
           valueFrom:

--- a/charts/risingwave/templates/secret.yaml
+++ b/charts/risingwave/templates/secret.yaml
@@ -11,7 +11,9 @@ metadata:
   {{- end }}
 stringData:
   root-user: {{ .Values.auth.rootUser | quote }}
+  {{- if not .Values.auth.existingSecretName }}
   root-password: {{ .Values.auth.rootPassword | quote }}
+  {{- end }}
   {{- if ne .Values.auth.rootUser "root" }}
   real-root-password: {{ randAlphaNum 8 | quote }}
   {{- end }}

--- a/charts/risingwave/tests/secret_test.yaml
+++ b/charts/risingwave/tests/secret_test.yaml
@@ -76,3 +76,33 @@ tests:
   - notEqual:
       path: stringData.real-root-password
       value: ""
+- it: secret contains only root user when existing secret is provided
+  set:
+    auth:
+      rootUser: root
+      existingSecretName: SECRET_NAME
+  asserts:
+  - equal:
+      path: stringData.root-user
+      value: root
+  - notExists:
+      path: stringData.root-password
+  - notExists:
+      path: stringData.real-root-password
+- it: secret must reflect root user and real root password when existing secret is provided
+  set:
+    auth:
+      rootUser: ROOT_USER
+      rootPassword: ROOT_PASSWORD
+      existingSecretName: SECRET_NAME
+  asserts:
+  - equal:
+      path: stringData.root-user
+      value: ROOT_USER
+  - notExists:
+      path: stringData.root-password
+  - exists:
+      path: stringData.real-root-password
+  - notEqual:
+      path: stringData.real-root-password
+      value: ""

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1280,6 +1280,11 @@ auth:
   ## Empty string means no password.
   ##
   rootPassword: ""
+  ## @param auth.existingSecretName Use existing Secret to provide root password.
+  ## If set, value of rootPassword will be ignored.
+  ## Secret must contain `root-password` key.
+  ##
+  existingSecretName: ""
 
 ## @section RisingWave databases.
 ##


### PR DESCRIPTION
Add a new field under the `auth` section to let the user specify a secret to provide the password for root user.