### PR TITLE
chore: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Helm Charts for RisingWave
 ## Prerequisites
 
 - Kubernetes cluster (version >= 1.24)
-- [Helm](https://helm.sh/docs/intro/install/) (version >= 3.7)
+- [Helm](https://helm.sh/docs/intro/install/) (version >= 3.10)
 
 ## Installation
 


### PR DESCRIPTION
Helm 3.9 has a problem of templating. Since the latest version is 3.15 now, let's bump the minimum requirement.

```
Error: parse error at (risingwave/charts/common/templates/_resources.tpl:15): unclosed action
```