### PR TITLE
feat: support advertising with IP to bypass DNS problems

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.65
+version: 0.1.66
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -243,7 +243,11 @@ spec:
         - name: RW_LISTEN_ADDR
           value: "0.0.0.0:{{ .Values.ports.compute.svc }}"
         - name: RW_ADVERTISE_ADDR
+        {{- if .Values.computeComponent.advertisingWithIP }}
+          value: "$(POD_IP):{{ .Values.ports.compute.svc }}"
+        {{- else }}
           value: "$(POD_NAME).{{ include "risingwave.computeHeadlessServiceName" . }}.$(POD_NAMESPACE).svc:{{ .Values.ports.compute.svc }}"
+        {{- end }}
         - name: RW_PROMETHEUS_LISTENER_ADDR
           value: "0.0.0.0:{{ .Values.ports.compute.metrics }}"
         - name: RW_META_ADDR

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -236,7 +236,11 @@ spec:
         - name: RW_LISTEN_ADDR
           value: {{ printf "0.0.0.0:%d" (.Values.ports.meta.svc | int)}}
         - name: RW_ADVERTISE_ADDR
+        {{- if .Values.metaComponent.advertisingWithIP }}
+          value: "$(POD_IP):{{ .Values.ports.meta.svc }}"
+        {{- else }}
           value: "$(POD_NAME).{{ include "risingwave.metaHeadlessServiceName" . }}.$(POD_NAMESPACE).svc:{{ .Values.ports.meta.svc }}"
+        {{- end }}
         - name: RW_PROMETHEUS_HOST
           value: "0.0.0.0:{{ .Values.ports.meta.metrics }}"
         - name: RW_STATE_STORE

--- a/charts/risingwave/tests/advertising_with_ip_test.yaml
+++ b/charts/risingwave/tests/advertising_with_ip_test.yaml
@@ -1,0 +1,50 @@
+suite: Test HorizontalPodAutoscaler
+templates:
+- meta-sts.yaml
+- compute-sts.yaml
+chart:
+  appVersion: 1.0.0
+  version: 0.0.1
+tests:
+- it: Advertising with IP affects the advertising address (meta)
+  templates:
+  - meta-sts.yaml
+  set:
+    metaComponent:
+      advertisingWithIP: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_ADVERTISE_ADDR
+        value: "$(POD_IP):5690"
+- it: Advertising with IP affects the advertising address (compute)
+  templates:
+  - compute-sts.yaml
+  set:
+    computeComponent:
+      advertisingWithIP: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_ADVERTISE_ADDR
+        value: "$(POD_IP):5688"
+- it: Advertising with IP changes nothing by default (meta)
+  templates:
+  - meta-sts.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_ADVERTISE_ADDR
+        value: "$(POD_NAME).RELEASE-NAME-risingwave-meta-headless.$(POD_NAMESPACE).svc:5690"
+- it: Advertising with IP changes nothing by default (compute)
+  templates:
+  - compute-sts.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_ADVERTISE_ADDR
+        value: "$(POD_NAME).RELEASE-NAME-risingwave-compute-headless.$(POD_NAMESPACE).svc:5688"

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -835,6 +835,11 @@ metaComponent:
     whenDeleted: Delete
     whenScaled: Delete
 
+  ## @param metaComponent.advertisingWithIP Enable advertising with IP.
+  ## Defaults to false.
+  ##
+  advertisingWithIP: false
+
 frontendComponent:
   ## @param frontendComponent.podLabels Labels to add to the component pods.
   ##
@@ -1073,6 +1078,11 @@ computeComponent:
   autoDeregistration:
     ## @param autoDeregistration.enabled Enable auto-deregistration.
     enabled: false
+
+  ## @param metaComponent.advertisingWithIP Enable advertising with IP.
+  ## Defaults to false.
+  ##
+  advertisingWithIP: false
 
 compactorComponent:
   ## @param compactorComponent.podLabels Labels to add to the component pods.


### PR DESCRIPTION
The same feature as introduced in https://github.com/risingwavelabs/risingwave-operator/pull/682.

Release 0.1.66.