### PR TITLE
feat: support bundled PostgreSQL

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.68
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -36,7 +36,12 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   tags:
   - etcd
+- name: postgresql
+  version: 15.x.x
+  repository: https://charts.bitnami.com/bitnami
+  tags:
   - bundle
+  - postgresql
 - name: minio
   version: 13.x.x
   repository: https://charts.bitnami.com/bitnami

--- a/charts/risingwave/templates/hooks/post-install-create-databases.yaml
+++ b/charts/risingwave/templates/hooks/post-install-create-databases.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: create-databases
-        image: {{ .Values.postgresql.image }}
+        image: {{ .Values.postgresqlClient.image }}
         env:
         - name: PG_HOSTNAME
           value: {{ include "risingwave.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/risingwave/templates/hooks/post-install-create-root-user.yaml
+++ b/charts/risingwave/templates/hooks/post-install-create-root-user.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: create-root-user
-        image: {{ .Values.postgresql.image }}
+        image: {{ .Values.postgresqlClient.image }}
         env:
         - name: PG_HOSTNAME
           value: {{ include "risingwave.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -148,7 +148,7 @@ spec:
         - secretRef:
             name: {{ include "risingwave.etcdCredentialsSecretName" . }}
         {{- end }}
-        {{- if .Values.metaStore.postgresql.enabled }}
+        {{- if or (include "risingwave.bundle.postgresql.enabled" . ) .Values.metaStore.postgresql.enabled }}
         - secretRef:
             name: {{ include "risingwave.postgresCredentialsSecretName" . }}
         {{- end }}

--- a/charts/risingwave/templates/metastore/postgres-secret.yaml
+++ b/charts/risingwave/templates/metastore/postgres-secret.yaml
@@ -3,8 +3,7 @@ Copyright RisingWave Labs
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.metaStore.postgresql.enabled }}
-{{- if not .Values.metaStore.postgresql.authentication.existingSecretName }}
+{{- if or (include "risingwave.bundle.postgresql.enabled" .) (and .Values.metaStore.postgresql.enabled (not .Values.metaStore.postgresql.authentication.existingSecretName)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,7 +16,11 @@ metadata:
     {{ nindent 4 $annotations }}
   {{- end }}
 stringData:
+  {{- if (include "risingwave.bundle.postgresql.enabled" .) }}
+  RW_POSTGRES_USERNAME: "postgres"
+  RW_POSTGRES_PASSWORD: {{ .Values.postgresql.auth.postgresPassword | quote }}
+  {{- else }}
   RW_POSTGRES_USERNAME: {{ .Values.metaStore.postgresql.authentication.username | quote }}
   RW_POSTGRES_PASSWORD: {{ .Values.metaStore.postgresql.authentication.password | quote }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/risingwave/templates/standalone/standalone-sts.yaml
+++ b/charts/risingwave/templates/standalone/standalone-sts.yaml
@@ -194,7 +194,7 @@ spec:
         - secretRef:
             name: {{ include "risingwave.etcdCredentialsSecretName" . }}
         {{- end }}
-        {{- if .Values.metaStore.postgresql.enabled }}
+        {{- if or (include "risingwave.bundle.postgresql.enabled" . ) .Values.metaStore.postgresql.enabled }}
         - secretRef:
             name: {{ include "risingwave.postgresCredentialsSecretName" . }}
         {{- end }}

--- a/charts/risingwave/templates/validation.yaml
+++ b/charts/risingwave/templates/validation.yaml
@@ -49,14 +49,13 @@ Validate meta store backends.
 */}}
 {{- $count = 0 -}}
 {{- $name = "" }}
-# Count without etcd.
+# Count without etcd and postgresql.
 {{- with .Values.metaStore }}
 {{/*  {{- if .etcd.enabled }}{{ $count = add1 $count }}{{ $name = "etcd" }}{{- end }}*/}}
 {{- if .sqlite.enabled }}{{ $count = add1 $count }}{{ $name = "sqlite" }}{{- end }}
 {{- if .mysql.enabled }}{{ $count = add1 $count }}{{ $name = "mysql" }}{{- end }}
-{{- if .postgresql.enabled }}{{ $count = add1 $count }}{{ $name = "postgresql" }}{{- end }}
 {{- end }}
-# If there's no state store and bundled minio enabled, count = 1
+# If there's no meta store and bundled etcd enabled, count = 1
 {{- if (include "risingwave.bundle.etcd.enabled" .) }}
   {{- if and (eq $count 0) }}
     {{ $count = add1 $count }}
@@ -67,8 +66,19 @@ Validate meta store backends.
 {{- else }}
   {{- if .Values.metaStore.etcd.enabled }}{{ $count = add1 $count }}{{ $name = "etcd" }}{{- end }}
 {{- end }}
+# If there's no meta store and bundled postgresql enabled, count = 1
+{{- if (include "risingwave.bundle.postgresql.enabled" .) }}
+  {{- if and (eq $count 0) }}
+    {{ $count = add1 $count }}
+    {{ $name = "postgresql" }}
+  {{- else }}
+    {{- printf "Unnecessary bundled postgresql when %s is enabled!" $name | fail }}
+  {{- end }}
+{{- else }}
+  {{- if .Values.metaStore.postgresql.enabled }}{{ $count = add1 $count }}{{ $name = "postgresql" }}{{- end }}
+{{- end }}
 {{- if (eq $count 0 ) }}
-  {{- fail "No meta store backend!\n  Please set up one of the backends under `metaStore`, or use the bundled one by setting `tags.etcd=true`!" }}
+  {{- fail "No meta store backend!\n  Please set up one of the backends under `metaStore`, or use the bundled one by setting `tags.postgresql=true`!" }}
 {{- else if (gt $count 1) }}
   {{- fail "More than one meta store backends!" }}
 {{- end }}
@@ -102,6 +112,7 @@ Validate parameters of sqlite meta store.
 {{/*
 Validate parameters of PostgreSQL meta store.
 */}}
+{{- if not (include "risingwave.bundle.postgresql.enabled" .) }}
 {{- if .Values.metaStore.postgresql.enabled }}
   {{- if empty .Values.metaStore.postgresql.host }}
     {{- fail "Host .metaStore.postgresql.host must be set!" }}
@@ -119,6 +130,7 @@ Validate parameters of PostgreSQL meta store.
       {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/risingwave/tests/metastore/etcd_secret_test.yaml
+++ b/charts/risingwave/tests/metastore/etcd_secret_test.yaml
@@ -5,15 +5,6 @@ chart:
   appVersion: 1.0.0
   version: 0.0.1
 tests:
-- it: bundled etcd should not render secret .tags.bundle
-  set:
-    tags.bundle: true
-    metaStore.etcd.authentication:
-      enabled: true
-      existingSecretName: EXISTING_SECRET_NAME
-  asserts:
-  - hasDocuments:
-      count: 0
 - it: bundled etcd should not render secret .tags.etcd
   set:
     tags.etcd: true

--- a/charts/risingwave/tests/metastore/meta-sts_env_test.yaml
+++ b/charts/risingwave/tests/metastore/meta-sts_env_test.yaml
@@ -288,6 +288,46 @@ tests:
           secretKeyRef:
             key: password
             name: s
+- it: envs must contain necessary ones (postgres, tags.postgresql)
+  set:
+    tags:
+      postgresql: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: sql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@RELEASE-NAME-postgresql:5432/risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs must contain necessary ones (postgres, tags.bundle)
+  set:
+    tags:
+      bundle: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: sql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@RELEASE-NAME-postgresql:5432/risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
 # Tests for MySQL.
 ## true-negative (mysql)
 - it: envs must not contain RW_SQL_ENDPOINT (non-mysql)

--- a/charts/risingwave/tests/metastore/postgresql_secret_test.yaml
+++ b/charts/risingwave/tests/metastore/postgresql_secret_test.yaml
@@ -5,6 +5,24 @@ chart:
   appVersion: 1.0.0
   version: 0.0.1
 tests:
+- it: bundled postgresql should still render secret .tags.postgresql
+  set:
+    tags.postgresql: true
+    metaStore.postgresql.authentication:
+      enabled: true
+      existingSecretName: EXISTING_SECRET_NAME
+  asserts:
+  - hasDocuments:
+      count: 1
+- it: bundled postgresql should still render secret .tags.bundle
+  set:
+    tags.bundle: true
+    metaStore.postgresql.authentication:
+      enabled: true
+      existingSecretName: EXISTING_SECRET_NAME
+  asserts:
+  - hasDocuments:
+      count: 1
 - it: postgresql with existing secret should not render secret
   set:
       metaStore.postgresql.authentication:

--- a/charts/risingwave/tests/statestore/statestore_validation_test.yaml
+++ b/charts/risingwave/tests/statestore/statestore_validation_test.yaml
@@ -5,7 +5,7 @@ chart:
   appVersion: 1.0.0
   version: 0.0.1
 set:
-  tags.etcd: true
+  tags.postgresql: true
 tests:
 - it: bundled minio should pass
   set:

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -5,8 +5,8 @@
 ## Ref: https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies
 ##
 tags:
-  ## @param tags.bundle Tag to control all bundled dependencies, including bitnami/etcd
-  ## and bitnami/minio. Please refer to tags.etcd and tags.minio for more details.
+  ## @param tags.bundle Tag to control all bundled dependencies, including bitnami/postgresql
+  ## and bitnami/minio. Please refer to tags.postgresql and tags.minio for more details.
   ## @values true, false
   ##
   bundle: false
@@ -15,6 +15,10 @@ tags:
   ## @values true,false
   ##
   etcd: false
+
+  ## @param tags.postgresql Tag to control the bitnami/postgresql dependency.
+  ## @values true, false
+  postgresql: false
 
   ## @param tags.minio Tag to control the bitnami/minio dependency.
   ## @values true,false
@@ -66,6 +70,22 @@ etcd:
     value: "10000"
   - name: "ETCD_MAX_TXN_OPS"
     value: "999999"
+
+## @section Values for the bitnami/postgresql dependency.
+## Ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+##
+postgresql:
+  auth:
+    postgresPassword: "postgres"
+    database: "risingwave"
+
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+    service:
+      ports:
+        postgresql: 5432
 
 ## @section Values for the bitnami/minio dependency.
 ## Ref: https://github.com/bitnami/charts/blob/main/bitnami/minio/values.yaml
@@ -1311,8 +1331,8 @@ databases: [ ]
 ##
 wait: false
 
-postgresql:
-  ## @param postgresql.image PostgreSQL image.
+postgresqlClient:
+  ## @param postgresqlClient.image PostgreSQL image for client usages.
   ##
   image: postgres:16.2
 

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -80,9 +80,14 @@ postgresql:
     database: "risingwave"
 
   primary:
+    resourcesPreset: "none"
     persistence:
       enabled: true
       size: 8Gi
+    persistentVolumeClaimRetentionPolicy:
+      enabled: true
+      whenScaled: Retain
+      whenDeleted: Delete
     service:
       ports:
         postgresql: 5432

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -156,11 +156,12 @@ stateStore:
 
 For the details of a backend, please check the values of the corresponding section.
 
-### Bundled etcd/MinIO as Stores
+### Bundled etcd/PostgreSQL/MinIO as Stores
 
 Helm chart for RisingWave also provides an option to deploy the etcd and MinIO along with the RisingWave to provide meta
-and state store backends. It is useful to try out the helm chart quickly. The feature is achieved with `bitnami/etcd`
-and `bitnami/minio` sub-charts. If you are interested in these charts, please refer
+and state store backends. It is useful to try out the helm chart quickly. The feature is achieved
+with `bitnami/etcd`, `bitnami/postgresql` and `bitnami/minio` sub-charts. If you are interested in
+these charts, please refer
 to [bitnami/charts](https://github.com/bitnami) for details.
 
 Set the `tags.bundle` option to `true` to experience the feature.
@@ -169,17 +170,19 @@ Set the `tags.bundle` option to `true` to experience the feature.
 helm install --set tags.bundle=true risingwave risingwavelabs/risingwave
 ```
 
-It's also possible to control the enablement of etcd and MinIO sub-charts separately with `tags.etcd` and `tags.minio`.
-But note that `tags.bundle` must be `false` when you want such control.
+It's also possible to control the enablement of etcd and MinIO sub-charts separately with
+`tags.etcd` (deprecating),
+`tags.postgresql` and `tags.minio`. But note that `tags.bundle` must be `false` when you want such
+control.
 
 > [!TIP]
 >
-> etcd is recommended as the default meta store backend. Simply using the following values to deploy it with RisingWave
-> so that you can focus on setting the state store.
+> PostgreSQL is recommended as the default meta store backend. Simply using the following values to
+> deploy it with RisingWave so that you can focus on setting the state store.
 >
 > ```yaml
 > tags:
->   etcd: true
+>   postgresql: true
 > ```
 
 ### IAM Role for ServiceAccount (EKS) and Others


### PR DESCRIPTION
As title, two breaking changes introduced:
- `tags.bundle` won't enable `etcd` anymore
- `postgresql` will be used for specifying values of the bundled `bitnami/postgresql`, original one is renamed to `postgresqlClient`

In that, the next chart version will be `0.2.0`.

Upgrade notice:
- Change `postgresql` section to `postgresqlClient`
- If `tags.bundle=true` is set, set it to false, and then set `tags.etcd=true` and `tags.minio=true` instead
