### PR TITLE
feat: support new way to pass credentials for SQL backends

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -108,6 +108,8 @@ spec:
       enableServiceLinks: false
       preemptionPolicy: PreemptLowerPriority
       setHostnameAsFQDN: false
+      initContainers:
+      {{- include "risingwave.metaInitContainers" . | nindent 6 }}
       containers:
       - name: meta
         image: {{ include "risingwave.image" . }}
@@ -309,10 +311,11 @@ spec:
               key: password
               name: {{ .Values.metaStore.mysql.authentication.existingSecretName }}
         {{- end }}
-        {{- if eq (include "risingwave.metaBackend" . ) "sql" }}
+        {{- if (include "risingwave.sqlEndpoint" . ) }}
         - name: RW_SQL_ENDPOINT
           value: {{ include "risingwave.sqlEndpoint" . }}
         {{- end }}
+        {{ include "risingwave.metaStoreSQLBackendCredentialEnvs" . | nindent 8 }}
         resources:
           {{- if .Values.metaComponent.resources.limits }}
           limits:

--- a/charts/risingwave/templates/standalone/standalone-sts.yaml
+++ b/charts/risingwave/templates/standalone/standalone-sts.yaml
@@ -115,6 +115,8 @@ spec:
       enableServiceLinks: false
       preemptionPolicy: PreemptLowerPriority
       setHostnameAsFQDN: false
+      initContainers:
+      {{- include "risingwave.metaInitContainers" . | nindent 6 }}
       containers:
       - name: standalone
         image: {{ include "risingwave.image" . }}
@@ -133,21 +135,21 @@ spec:
             --dashboard-host 0.0.0.0:{{ .Values.ports.meta.dashboard }}
             --prometheus-host 0.0.0.0:{{ .Values.ports.frontend.metrics }}
             --backend $(RW_BACKEND)
-            {{- if .Values.metaStore.etcd.enabled }}
+            {{- if or .Values.metaStore.etcd.enabled (include "risingwave.bundle.etcd.enabled" .) }}
             --etcd-endpoints $(RW_ETCD_ENDPOINTS)
             {{- end }}
-            {{- if eq (include "risingwave.metaBackend" . ) "sql" }}
+            {{- if (include "risingwave.sqlEndpoint" .) }}
             --sql-endpoint $(RW_SQL_ENDPOINT)
             {{- end }}
             --state-store $(RW_STATE_STORE)
             --data-directory $(RW_DATA_DIRECTORY)
-        {{- if (include "risingwave.bundle.etcd.enabled" .) }}
-        {{- if and (not .Values.etcd.auth.rbac.allowNoneAuthentication) .Values.etcd.auth.rbac.create }}
+            {{- if (include "risingwave.bundle.etcd.enabled" .) }}
+            {{- if and (not .Values.etcd.auth.rbac.allowNoneAuthentication) .Values.etcd.auth.rbac.create }}
             --etcd-auth
             --etcd-username $(RW_ETCD_USERNAME)
             --etcd-password $(RW_ETCD_PASSWORD)
-        {{- end }}
-        {{- end }}
+            {{- end }}
+            {{- end }}
         - >-
           --compute-opts=--listen-addr 127.0.0.1:{{ .Values.ports.compute.svc }}
             --prometheus-listener-addr 0.0.0.0:{{ .Values.ports.frontend.metrics }}
@@ -340,10 +342,11 @@ spec:
               key: password
               name: {{ .Values.metaStore.mysql.authentication.existingSecretName }}
         {{- end }}
-        {{- if eq (include "risingwave.metaBackend" . ) "sql" }}
+        {{- if (include "risingwave.sqlEndpoint" .) }}
         - name: RW_SQL_ENDPOINT
           value: {{ include "risingwave.sqlEndpoint" . }}
         {{- end }}
+        {{ include "risingwave.metaStoreSQLBackendCredentialEnvs" . | nindent 8 }}
         {{- if .Values.tls.existingSecretName }}
         - name: RW_SSL_CERT
           value: /risingwave/certs/tls.crt

--- a/charts/risingwave/tests/metastore/meta-sts_env_test.yaml
+++ b/charts/risingwave/tests/metastore/meta-sts_env_test.yaml
@@ -182,9 +182,10 @@ tests:
         name: RW_SQL_ENDPOINT
       any: true
 ## true-positive (sqlite)
-- it: envs must contain necessary ones (sqlite)
+- it: envs must contain necessary ones (sqlite, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       sqlite:
         enabled: true
         path: /risingwave.db
@@ -199,6 +200,24 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: sqlite:///risingwave.db?mode=rwc
+- it: envs must contain necessary ones (sqlite)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      sqlite:
+        enabled: true
+        path: /risingwave.db
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: sqlite
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: /risingwave.db
 # Tests for PostgreSQL.
 ## true-negative (postgres)
 - it: envs must not contain RW_SQL_ENDPOINT (non-postgres)
@@ -209,9 +228,10 @@ tests:
         name: RW_SQL_ENDPOINT
       any: true
 ## true-positive (postgres)
-- it: envs must contain necessary ones (postgres)
+- it: envs must contain necessary ones (postgres, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       postgresql:
         enabled: true
         host: host
@@ -236,9 +256,10 @@ tests:
       content:
         secretRef:
           name:  RELEASE-NAME-risingwave-postgres
-- it: envs should reflect options
+- it: envs should reflect options (postgres, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       postgresql:
         enabled: true
         host: host
@@ -256,9 +277,10 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@host:5432/risingwave?a=b&c=d%3De
-- it: envs must reflect existing secret (postgres)
+- it: envs must reflect existing secret (postgres, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       postgresql:
         enabled: true
         host: host
@@ -288,10 +310,12 @@ tests:
           secretKeyRef:
             key: password
             name: s
-- it: envs must contain necessary ones (postgres, tags.postgresql)
+- it: envs must contain necessary ones (postgres, tags.postgresql, legacy)
   set:
     tags:
       postgresql: true
+    metaStore:
+      passSQLCredentialsLegacyMode: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -308,10 +332,12 @@ tests:
       content:
         secretRef:
           name:  RELEASE-NAME-risingwave-postgres
-- it: envs must contain necessary ones (postgres, tags.bundle)
+- it: envs must contain necessary ones (postgres, tags.bundle, legacy)
   set:
     tags:
       bundle: true
+    metaStore:
+      passSQLCredentialsLegacyMode: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -323,6 +349,187 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@RELEASE-NAME-postgresql:5432/risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs must contain necessary ones (postgres)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      postgresql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs should reflect options (postgres)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      postgresql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        options:
+          a: b
+          c: d=e
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432?a=b&c=d%3De
+- it: envs must reflect existing secret (postgres)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      postgresql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          existingSecretName: s
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name: RELEASE-NAME-risingwave-postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_POSTGRES_USERNAME
+        valueFrom:
+          secretKeyRef:
+            key: username
+            name: s
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_POSTGRES_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: password
+            name: s
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+- it: envs must contain necessary ones (postgres, tags.postgresql)
+  set:
+    tags:
+      postgresql: true
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: RELEASE-NAME-postgresql:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs must contain necessary ones (postgres, tags.bundle)
+  set:
+    tags:
+      bundle: true
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: RELEASE-NAME-postgresql:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
   - contains:
       path: spec.template.spec.containers[0].envFrom
       content:
@@ -338,9 +545,10 @@ tests:
         name: RW_SQL_ENDPOINT
       any: true
 ## true-positive (mysql)
-- it: envs must contain necessary ones (mysql)
+- it: envs must contain necessary ones (mysql, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       mysql:
         enabled: true
         host: host
@@ -365,9 +573,10 @@ tests:
       content:
         secretRef:
           name:  RELEASE-NAME-risingwave-mysql
-- it: envs should reflect options
+- it: envs should reflect options (mysql, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       mysql:
         enabled: true
         host: host
@@ -385,9 +594,107 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: mysql://$(RW_MYSQL_USERNAME):$(RW_MYSQL_PASSWORD)@host:5432/risingwave?a=b&c=d%3De
+- it: envs must reflect existing secret (mysql, legacy)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: true
+      mysql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          existingSecretName: s
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name: RELEASE-NAME-risingwave-mysql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_MYSQL_USERNAME
+        valueFrom:
+          secretKeyRef:
+            key: username
+            name: s
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_MYSQL_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: password
+            name: s
+- it: envs must contain necessary ones (mysql)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      mysql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: mysql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_MYSQL_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_MYSQL_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-mysql
+- it: envs should reflect options (mysql)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      mysql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        options:
+          a: b
+          c: d=e
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432?a=b&c=d%3De
 - it: envs must reflect existing secret (mysql)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: false
       mysql:
         enabled: true
         host: host

--- a/charts/risingwave/tests/metastore/standalone-sts_env_test.yaml
+++ b/charts/risingwave/tests/metastore/standalone-sts_env_test.yaml
@@ -184,9 +184,10 @@ tests:
         name: RW_SQL_ENDPOINT
       any: true
 ## true-positive (sqlite)
-- it: envs must contain necessary ones (sqlite)
+- it: envs must contain necessary ones (sqlite, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       sqlite:
         enabled: true
         path: /risingwave.db
@@ -201,6 +202,24 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: sqlite:///risingwave.db?mode=rwc
+- it: envs must contain necessary ones (sqlite)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      sqlite:
+        enabled: true
+        path: /risingwave.db
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: sqlite
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: /risingwave.db
 # Tests for PostgreSQL.
 ## true-negative (postgres)
 - it: envs must not contain RW_SQL_ENDPOINT (non-postgres)
@@ -211,9 +230,10 @@ tests:
         name: RW_SQL_ENDPOINT
       any: true
 ## true-positive (postgres)
-- it: envs must contain necessary ones (postgres)
+- it: envs must contain necessary ones (postgres, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       postgresql:
         enabled: true
         host: host
@@ -238,9 +258,10 @@ tests:
       content:
         secretRef:
           name:  RELEASE-NAME-risingwave-postgres
-- it: envs should reflect options
+- it: envs should reflect options (postgres, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       postgresql:
         enabled: true
         host: host
@@ -258,9 +279,10 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@host:5432/risingwave?a=b&c=d%3De
-- it: envs must reflect existing secret (postgres)
+- it: envs must reflect existing secret (postgres, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       postgresql:
         enabled: true
         host: host
@@ -290,6 +312,231 @@ tests:
           secretKeyRef:
             key: password
             name: s
+- it: envs must contain necessary ones (postgres, tags.postgresql, legacy)
+  set:
+    tags:
+      postgresql: true
+    metaStore:
+      passSQLCredentialsLegacyMode: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: sql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@RELEASE-NAME-postgresql:5432/risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs must contain necessary ones (postgres, tags.bundle, legacy)
+  set:
+    tags:
+      bundle: true
+    metaStore:
+      passSQLCredentialsLegacyMode: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: sql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: postgres://$(RW_POSTGRES_USERNAME):$(RW_POSTGRES_PASSWORD)@RELEASE-NAME-postgresql:5432/risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs must contain necessary ones (postgres)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      postgresql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs should reflect options (postgres)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      postgresql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        options:
+          a: b
+          c: d=e
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432?a=b&c=d%3De
+- it: envs must reflect existing secret (postgres)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      postgresql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          existingSecretName: s
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name: RELEASE-NAME-risingwave-postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_POSTGRES_USERNAME
+        valueFrom:
+          secretKeyRef:
+            key: username
+            name: s
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_POSTGRES_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: password
+            name: s
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+- it: envs must contain necessary ones (postgres, tags.postgresql)
+  set:
+    tags:
+      postgresql: true
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: RELEASE-NAME-postgresql:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
+- it: envs must contain necessary ones (postgres, tags.bundle)
+  set:
+    tags:
+      bundle: true
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: postgres
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: RELEASE-NAME-postgresql:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_POSTGRES_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_POSTGRES_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-postgres
 # Tests for MySQL.
 ## true-negative (mysql)
 - it: envs must not contain RW_SQL_ENDPOINT (non-mysql)
@@ -300,9 +547,10 @@ tests:
         name: RW_SQL_ENDPOINT
       any: true
 ## true-positive (mysql)
-- it: envs must contain necessary ones (mysql)
+- it: envs must contain necessary ones (mysql, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       mysql:
         enabled: true
         host: host
@@ -327,9 +575,10 @@ tests:
       content:
         secretRef:
           name:  RELEASE-NAME-risingwave-mysql
-- it: envs should reflect options
+- it: envs should reflect options (mysql, legacy)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: true
       mysql:
         enabled: true
         host: host
@@ -347,9 +596,107 @@ tests:
       content:
         name: RW_SQL_ENDPOINT
         value: mysql://$(RW_MYSQL_USERNAME):$(RW_MYSQL_PASSWORD)@host:5432/risingwave?a=b&c=d%3De
+- it: envs must reflect existing secret (mysql, legacy)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: true
+      mysql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          existingSecretName: s
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name: RELEASE-NAME-risingwave-mysql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_MYSQL_USERNAME
+        valueFrom:
+          secretKeyRef:
+            key: username
+            name: s
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_MYSQL_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: password
+            name: s
+- it: envs must contain necessary ones (mysql)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      mysql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_BACKEND
+        value: mysql
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_USERNAME
+        value: $(RW_MYSQL_USERNAME)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_PASSWORD
+        value: $(RW_MYSQL_PASSWORD)
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_DATABASE
+        value: risingwave
+  - contains:
+      path: spec.template.spec.containers[0].envFrom
+      content:
+        secretRef:
+          name:  RELEASE-NAME-risingwave-mysql
+- it: envs should reflect options (mysql)
+  set:
+    metaStore:
+      passSQLCredentialsLegacyMode: false
+      mysql:
+        enabled: true
+        host: host
+        port: 5432
+        database: risingwave
+        options:
+          a: b
+          c: d=e
+        authentication:
+          username: u
+          password: p
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_SQL_ENDPOINT
+        value: host:5432?a=b&c=d%3De
 - it: envs must reflect existing secret (mysql)
   set:
     metaStore:
+      passSQLCredentialsLegacyMode: false
       mysql:
         enabled: true
         host: host

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -374,6 +374,15 @@ standalone:
 ##
 
 metaStore:
+  ## @param metaStore.passSQLCredentialsLegacyMode Enable/disable the legacy mode of passing credentials of SQL backends.
+  ## The legacy mode is supported for backward compatibility. It is recommended to use the new mode.
+  ## However, the legacy mode has a limitation that the credentials are passed in the URL, which doesn't
+  ## allow special characters in the username/password. They need to be URL-encoded to work.
+  ##
+  ## The new mode is supported starting from v1.10.1.
+  ##
+  passSQLCredentialsLegacyMode: false
+
   ## @section metaStore.etcd only takes effect when tags.etcd is false.
   ##
   etcd:
@@ -864,6 +873,11 @@ metaComponent:
   ## Defaults to false.
   ##
   advertisingWithIP: false
+
+  ## @param metaComponent.waitForMetaStore Wait for the meta store to be ready.
+  ## Defaults to false. When bundled PostgreSQL is enabled, this will be automatically set to true.
+  ##
+  waitForMetaStore: false
 
 frontendComponent:
   ## @param frontendComponent.podLabels Labels to add to the component pods.


### PR DESCRIPTION
- Add an option `metaStore. passSQLCredentialsLegacyMode` to control the behaviour. When it's set to `false` (default), the new way is adopted. Otherwise, it will follow the legacy way.
- Add an option `metaComponent. waitForMetaStore` to control whether to have an init container to wait for the PostgreSQL/MySQL to be up before starting the meta pod.