### PR TITLE
risingwave-opeator: add missing pullSecrets in template

### DIFF
--- a/charts/risingwave-operator/templates/deployment.yaml
+++ b/charts/risingwave-operator/templates/deployment.yaml
@@ -16,6 +16,12 @@ metadata:
     {{ nindent 4 $annotations }}
   {{- end }}
 spec:
+  {{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+  {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.manager.updateStrategy }}
   strategy:
     {{- toYaml .Values.manager.updateStrategy | nindent 4 }}


### PR DESCRIPTION
The template of the deployment does not use the image.pullSecrets from the values file. Now it does.