### PR TITLE
feat: support passing license as file

### DIFF
--- a/charts/risingwave/templates/license-secret.yaml
+++ b/charts/risingwave/templates/license-secret.yaml
@@ -1,0 +1,12 @@
+{{- $secretName := (include "risingwave.licenseKeySecretName" .) }}
+{{- with .Values.license }}
+{{/* passAsFile && key != "" && (secret.key == "" || secret.name == "") */}}
+{{- if and .passAsFile .key (or (empty .secret.key) (empty .secret.name)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+stringData:
+  license.jwt: {{ .key }}
+{{- end }}
+{{- end }}

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -65,6 +65,7 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
+      {{ include "risingwave.licenseKeyVolume" . | nindent 6 }}
       - name: config
         configMap:
           name: {{ include "risingwave.configurationConfigMapName" . }}
@@ -327,6 +328,7 @@ spec:
             {{ toYaml .Values.metaComponent.resources.requests | nindent 12 }}
           {{- end }}
         volumeMounts:
+        {{ include "risingwave.licenseKeyVolumeMount" . | nindent 8 }}
         - mountPath: /risingwave/config
           name: config
           readOnly: true

--- a/charts/risingwave/templates/standalone/standalone-sts.yaml
+++ b/charts/risingwave/templates/standalone/standalone-sts.yaml
@@ -64,6 +64,7 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
+      {{ include "risingwave.licenseKeyVolume" . | nindent 6 }}
       - name: config
         configMap:
           name: {{ include "risingwave.configurationConfigMapName" . }}
@@ -367,6 +368,7 @@ spec:
             {{ toYaml .Values.standalone.resources.requests | nindent 12 }}
           {{- end }}
         volumeMounts:
+        {{ include "risingwave.licenseKeyVolumeMount" . | nindent 8 }}
         - mountPath: /risingwave/config
           name: config
           readOnly: true

--- a/charts/risingwave/tests/license_secret_test.yaml
+++ b/charts/risingwave/tests/license_secret_test.yaml
@@ -1,0 +1,56 @@
+suite: License secret test
+templates:
+- license-secret.yaml
+chart:
+  appVersion: 1.0.0
+  version: 0.0.1
+tests:
+- it: no license key
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: license key found with raw key and not passing by file
+  set:
+    license:
+      key: "ABC"
+      passAsFile: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: license key found with secret and not passing by file
+  set:
+    license:
+      secret:
+        name: a
+        key: b
+      passAsFile: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: license key found with raw key and passing by file
+  set:
+    license:
+      key: "ABC"
+      passAsFile: true
+  asserts:
+  - hasDocuments:
+      count: 1
+  - containsDocument:
+      apiVersion: v1
+      kind: Secret
+  - equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-license
+  - equal:
+      path: stringData["license.jwt"]
+      value: "ABC"
+- it: license key found with secret and passing by file
+  set:
+    license:
+      secret:
+        name: a
+        key: b
+      passAsFile: true
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/risingwave/tests/license_standalone_test.yaml
+++ b/charts/risingwave/tests/license_standalone_test.yaml
@@ -15,7 +15,47 @@ tests:
       content:
         name: RW_LICENSE_KEY
       any: true
-- it: license key found with raw key
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: no license key and passing as file
+  set:
+    license:
+      passAsFile: true
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with raw key and not passing by file
   set:
     license:
       key: "ABC"
@@ -25,7 +65,53 @@ tests:
       content:
         name: RW_LICENSE_KEY
         value: "ABC"
-- it: license key found with secret ref
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with raw key and passing by file
+  set:
+    license:
+      key: "ABC"
+      passAsFile: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+        value: /license/license.jwt
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+        mountPath: /license
+        readOnly: true
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+        secret:
+          secretName: RELEASE-NAME-risingwave-license
+          items:
+          - key: license.jwt
+            path: license.jwt
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true
+- it: license key found with secret ref and not passing by file
   set:
     license:
       secret:
@@ -40,7 +126,55 @@ tests:
           secretKeyRef:
             name: LICENSE-SECRET
             key: LICENSE-KEY
-- it: license key found with secret ref and key
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with secret ref and passing by file
+  set:
+    license:
+      secret:
+        name: LICENSE-SECRET
+        key: LICENSE-KEY
+      passAsFile: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+        value: /license/license.jwt
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+        mountPath: /license
+        readOnly: true
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+        secret:
+          secretName: LICENSE-SECRET
+          items:
+          - key: LICENSE-KEY
+            path: license.jwt
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true
+- it: license key found with secret ref and key and not passing by file
   set:
     license:
       key: "ABC"
@@ -56,3 +190,52 @@ tests:
           secretKeyRef:
             name: LICENSE-SECRET
             key: LICENSE-KEY
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with secret ref and key and passing by file
+  set:
+    license:
+      key: "ABC"
+      secret:
+        name: LICENSE-SECRET
+        key: LICENSE-KEY
+      passAsFile: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+        value: /license/license.jwt
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+        mountPath: /license
+        readOnly: true
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+        secret:
+          secretName: LICENSE-SECRET
+          items:
+          - key: LICENSE-KEY
+            path: license.jwt
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true

--- a/charts/risingwave/tests/license_test.yaml
+++ b/charts/risingwave/tests/license_test.yaml
@@ -12,7 +12,47 @@ tests:
       content:
         name: RW_LICENSE_KEY
       any: true
-- it: license key found with raw key
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: no license key and passing as file
+  set:
+    license:
+      passAsFile: true
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with raw key and not passing by file
   set:
     license:
       key: "ABC"
@@ -22,7 +62,53 @@ tests:
       content:
         name: RW_LICENSE_KEY
         value: "ABC"
-- it: license key found with secret ref
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with raw key and passing by file
+  set:
+    license:
+      key: "ABC"
+      passAsFile: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+        value: /license/license.jwt
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+        mountPath: /license
+        readOnly: true
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+        secret:
+          secretName: RELEASE-NAME-risingwave-license
+          items:
+          - key: license.jwt
+            path: license.jwt
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true
+- it: license key found with secret ref and not passing by file
   set:
     license:
       secret:
@@ -37,7 +123,55 @@ tests:
           secretKeyRef:
             name: LICENSE-SECRET
             key: LICENSE-KEY
-- it: license key found with secret ref and key
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with secret ref and passing by file
+  set:
+    license:
+      secret:
+        name: LICENSE-SECRET
+        key: LICENSE-KEY
+      passAsFile: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+        value: /license/license.jwt
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+        mountPath: /license
+        readOnly: true
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+        secret:
+          secretName: LICENSE-SECRET
+          items:
+          - key: LICENSE-KEY
+            path: license.jwt
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true
+- it: license key found with secret ref and key and not passing by file
   set:
     license:
       key: "ABC"
@@ -53,3 +187,52 @@ tests:
           secretKeyRef:
             name: LICENSE-SECRET
             key: LICENSE-KEY
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+      any: true
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+      any: true
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+      any: true
+- it: license key found with secret ref and key and passing by file
+  set:
+    license:
+      key: "ABC"
+      secret:
+        name: LICENSE-SECRET
+        key: LICENSE-KEY
+      passAsFile: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY_PATH
+        value: /license/license.jwt
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: license
+        mountPath: /license
+        readOnly: true
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: license
+        secret:
+          secretName: LICENSE-SECRET
+          items:
+          - key: LICENSE-KEY
+            path: license.jwt
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: RW_LICENSE_KEY
+      any: true

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1401,9 +1401,14 @@ license:
   ## @param secret Use existing Secret to provide license key.
   ## If set, value of key will be ignored.
   secret:
-    ## @param name Name of the existing Secret.
+    ## @param name of the existing Secret.
     ##
     name: ""
-    ## @param key Key in the Secret. Defaults to "licenseKey".
+    ## @param key in the Secret. Defaults to "licenseKey".
     ##
     key: "licenseKey"
+
+  ## @param passAsFile Pass the license key as a file. Defaults to false.
+  ## Will be removed once RisingWave v2.1 is released.
+  ##
+  passAsFile: false


### PR DESCRIPTION
## Explanation in Detail

> [!NOTE]
> Same as what we did in https://github.com/risingwavelabs/risingwave-operator/pull/732, the environment variable used to pass the file path is `RW_LICENSE_KEY_PATH` due to [a mistake in the original PR](https://github.com/risingwavelabs/risingwave/pull/18768#discussion_r1794983086).

- Add an option `.license.passAsFile` in the values to allow explicitly enabling the feature in https://github.com/risingwavelabs/risingwave/pull/18768. 
- The PR maintains backward compatibility.

## Example values (tested locally)

```yaml
metaStore:
  sqlite:
    enabled: true
    
stateStore:
  localFs:
    enabled: true

standalone:
  enabled: true

license:
  secret:
    name: license
    key: license.jwt
  passAsFile: true

image:
  registry: ghcr.io
  repository: risingwavelabs/risingwave
  tag: nightly-20241009
```

## Expectations
- `select rw_test_paid_tier()` returns `t` instead of an error message when a valid license is specified.

## Future works
- When the v2.1 is released, `passAsFile` will be marked as deprecated in the next helm chart release.
- When the v2.2 is released, `passAsFile` will be removed as well as all the related branches.