### PR TITLE
chore: turn license.passAsFile to true and mark it as deprecated

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.11
+version: 0.2.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/tests/license_standalone_test.yaml
+++ b/charts/risingwave/tests/license_standalone_test.yaml
@@ -9,6 +9,9 @@ set:
     enabled: true
 tests:
 - it: no license key
+  set:
+    license:
+      passAsFile: false
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].env
@@ -59,6 +62,7 @@ tests:
   set:
     license:
       key: "ABC"
+      passAsFile: false
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -114,6 +118,7 @@ tests:
 - it: license key found with secret ref and not passing by file
   set:
     license:
+      passAsFile: false
       secret:
         name: LICENSE-SECRET
         key: LICENSE-KEY
@@ -177,6 +182,7 @@ tests:
 - it: license key found with secret ref and key and not passing by file
   set:
     license:
+      passAsFile: false
       key: "ABC"
       secret:
         name: LICENSE-SECRET

--- a/charts/risingwave/tests/license_test.yaml
+++ b/charts/risingwave/tests/license_test.yaml
@@ -6,6 +6,9 @@ chart:
   version: 0.0.1
 tests:
 - it: no license key
+  set:
+    license:
+      passAsFile: false
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].env
@@ -56,6 +59,7 @@ tests:
   set:
     license:
       key: "ABC"
+      passAsFile: false
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -111,6 +115,7 @@ tests:
 - it: license key found with secret ref and not passing by file
   set:
     license:
+      passAsFile: false
       secret:
         name: LICENSE-SECRET
         key: LICENSE-KEY
@@ -174,6 +179,7 @@ tests:
 - it: license key found with secret ref and key and not passing by file
   set:
     license:
+      passAsFile: false
       key: "ABC"
       secret:
         name: LICENSE-SECRET

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1434,7 +1434,8 @@ license:
     ##
     key: "licenseKey"
 
-  ## @param passAsFile Pass the license key as a file. Defaults to false.
-  ## Will be removed once RisingWave v2.1 is released.
+  ## Deprecated. Will be removed once RisingWave v2.2 is released.
+  ## @param passAsFile Pass the license key as a file. Defaults to true.
+  ## Set it to false if you are deploying RisingWave < v2.1.
   ##
-  passAsFile: false
+  passAsFile: true


### PR DESCRIPTION
Close #125