### PR TITLE
feat: note about backing up auto-generated secret private key

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.18
+version: 0.2.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/NOTES.txt
+++ b/charts/risingwave/templates/NOTES.txt
@@ -45,3 +45,12 @@ Keep the above command running and open a new terminal window to run the followi
     psql {{ $psqlHostArgs -}} -p {{ $port }} -d {{ $firstDatabase }} -U {{ .Values.auth.rootUser }} {{ $psqlExtraArgs }}
 
 For more advanced applications, refer to our documentation at: https://www.risingwave.dev
+
+{{- if and (empty .Values.secretStore.privateKey.value) (or (empty .Values.secretStore.privateKey.secretRef.name) (empty .Values.secretStore.privateKey.secretRef.key)) }}
+
+IMPORTANT:
+The private key for the secret store is automatically generated and stored in a Kubernetes secret. Please back up the private key by running the following command:
+
+    {{ $kubectlArgs }} get secret {{ (include "risingwave.secretStoreSecretName" .) }} -o jsonpath="{.data.privateKey}" | base64 --decode
+
+{{- end }}


### PR DESCRIPTION
For example, the following notes will show when a user doesn't specify the key:

```plain
IMPORTANT:
The private key for the secret store is automatically generated and stored in a Kubernetes secret. Please back up the private key by running the following command:

    kubectl get secret risingwave-secret-store -o jsonpath="{.data.privateKey}" | base64 --decode
```