### PR TITLE
Remove parameter passAsFile from tests and values.yaml

### DIFF
--- a/charts/risingwave/templates/_helpers.tpl
+++ b/charts/risingwave/templates/_helpers.tpl
@@ -601,7 +601,7 @@ Cloud related enviroments.
 
 {{/* Env vars for license key */}}
 {{- define "risingwave.licenseKeyEnv" }}
-{{- if and .Values.license.passAsFile (or .Values.license.key (and .Values.license.secret.key .Values.license.secret.name)) }}
+{{- if or .Values.license.key (and .Values.license.secret.key .Values.license.secret.name) }}
 - name: RW_LICENSE_KEY_PATH
   value: /license/license.jwt
 {{- else if and .Values.license.secret.key .Values.license.secret.name }}
@@ -636,7 +636,7 @@ Cloud related enviroments.
 
 {{/* Volume for license key */}}
 {{- define "risingwave.licenseKeyVolume"}}
-{{- if and .Values.license.passAsFile (or .Values.license.key (and .Values.license.secret.key .Values.license.secret.name)) }}
+{{- if or .Values.license.key (and .Values.license.secret.key .Values.license.secret.name) }}
 - name: license
   secret:
     secretName: {{ include "risingwave.licenseKeySecretName" . | quote }}
@@ -648,7 +648,7 @@ Cloud related enviroments.
 
 {{/* Volume mount for license key */}}
 {{- define "risingwave.licenseKeyVolumeMount"}}
-{{- if and .Values.license.passAsFile (or .Values.license.key (and .Values.license.secret.key .Values.license.secret.name)) }}
+{{- if or .Values.license.key (and .Values.license.secret.key .Values.license.secret.name) }}
 - name: license
   mountPath: /license
   readOnly: true

--- a/charts/risingwave/templates/license-secret.yaml
+++ b/charts/risingwave/templates/license-secret.yaml
@@ -1,7 +1,7 @@
 {{- $secretName := (include "risingwave.licenseKeySecretName" .) }}
 {{- with .Values.license }}
-{{/* passAsFile && key != "" && (secret.key == "" || secret.name == "") */}}
-{{- if and .passAsFile .key (or (empty .secret.key) (empty .secret.name)) }}
+{{/* key != "" && (secret.key == "" || secret.name == "") */}}
+{{- if and .key (or (empty .secret.key) (empty .secret.name)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/risingwave/tests/license_secret_test.yaml
+++ b/charts/risingwave/tests/license_secret_test.yaml
@@ -9,29 +9,10 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
-- it: license key found with raw key and not passing by file
+- it: license key found with raw key
   set:
     license:
       key: "ABC"
-      passAsFile: false
-  asserts:
-  - hasDocuments:
-      count: 0
-- it: license key found with secret and not passing by file
-  set:
-    license:
-      secret:
-        name: a
-        key: b
-      passAsFile: false
-  asserts:
-  - hasDocuments:
-      count: 0
-- it: license key found with raw key and passing by file
-  set:
-    license:
-      key: "ABC"
-      passAsFile: true
   asserts:
   - hasDocuments:
       count: 1
@@ -44,13 +25,12 @@ tests:
   - equal:
       path: stringData["license.jwt"]
       value: "ABC"
-- it: license key found with secret and passing by file
+- it: license key found with secret
   set:
     license:
       secret:
         name: a
         key: b
-      passAsFile: true
   asserts:
   - hasDocuments:
       count: 0

--- a/charts/risingwave/tests/license_standalone_test.yaml
+++ b/charts/risingwave/tests/license_standalone_test.yaml
@@ -30,28 +30,6 @@ tests:
       content:
         name: license
       any: true
-- it: no license key
-  asserts:
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
 - it: license key found with raw key
   set:
     license:

--- a/charts/risingwave/tests/license_standalone_test.yaml
+++ b/charts/risingwave/tests/license_standalone_test.yaml
@@ -9,9 +9,6 @@ set:
     enabled: true
 tests:
 - it: no license key
-  set:
-    license:
-      passAsFile: false
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].env
@@ -33,10 +30,7 @@ tests:
       content:
         name: license
       any: true
-- it: no license key and passing as file
-  set:
-    license:
-      passAsFile: true
+- it: no license key
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].env
@@ -58,37 +52,10 @@ tests:
       content:
         name: license
       any: true
-- it: license key found with raw key and not passing by file
+- it: license key found with raw key
   set:
     license:
       key: "ABC"
-      passAsFile: false
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-        value: "ABC"
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with raw key and passing by file
-  set:
-    license:
-      key: "ABC"
-      passAsFile: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -115,44 +82,12 @@ tests:
       content:
         name: RW_LICENSE_KEY
       any: true
-- it: license key found with secret ref and not passing by file
-  set:
-    license:
-      passAsFile: false
-      secret:
-        name: LICENSE-SECRET
-        key: LICENSE-KEY
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-        valueFrom:
-          secretKeyRef:
-            name: LICENSE-SECRET
-            key: LICENSE-KEY
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with secret ref and passing by file
+- it: license key found with secret ref
   set:
     license:
       secret:
         name: LICENSE-SECRET
         key: LICENSE-KEY
-      passAsFile: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -179,46 +114,13 @@ tests:
       content:
         name: RW_LICENSE_KEY
       any: true
-- it: license key found with secret ref and key and not passing by file
-  set:
-    license:
-      passAsFile: false
-      key: "ABC"
-      secret:
-        name: LICENSE-SECRET
-        key: LICENSE-KEY
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-        valueFrom:
-          secretKeyRef:
-            name: LICENSE-SECRET
-            key: LICENSE-KEY
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with secret ref and key and passing by file
+- it: license key found with secret ref and key
   set:
     license:
       key: "ABC"
       secret:
         name: LICENSE-SECRET
         key: LICENSE-KEY
-      passAsFile: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env

--- a/charts/risingwave/tests/license_test.yaml
+++ b/charts/risingwave/tests/license_test.yaml
@@ -6,9 +6,6 @@ chart:
   version: 0.0.1
 tests:
 - it: no license key
-  set:
-    license:
-      passAsFile: false
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].env
@@ -30,62 +27,10 @@ tests:
       content:
         name: license
       any: true
-- it: no license key and passing as file
-  set:
-    license:
-      passAsFile: true
-  asserts:
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with raw key and not passing by file
+- it: license key found with raw key
   set:
     license:
       key: "ABC"
-      passAsFile: false
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-        value: "ABC"
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with raw key and passing by file
-  set:
-    license:
-      key: "ABC"
-      passAsFile: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -112,44 +57,12 @@ tests:
       content:
         name: RW_LICENSE_KEY
       any: true
-- it: license key found with secret ref and not passing by file
-  set:
-    license:
-      passAsFile: false
-      secret:
-        name: LICENSE-SECRET
-        key: LICENSE-KEY
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-        valueFrom:
-          secretKeyRef:
-            name: LICENSE-SECRET
-            key: LICENSE-KEY
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with secret ref and passing by file
+- it: license key found with secret ref
   set:
     license:
       secret:
         name: LICENSE-SECRET
         key: LICENSE-KEY
-      passAsFile: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
@@ -176,46 +89,13 @@ tests:
       content:
         name: RW_LICENSE_KEY
       any: true
-- it: license key found with secret ref and key and not passing by file
-  set:
-    license:
-      passAsFile: false
-      key: "ABC"
-      secret:
-        name: LICENSE-SECRET
-        key: LICENSE-KEY
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY
-        valueFrom:
-          secretKeyRef:
-            name: LICENSE-SECRET
-            key: LICENSE-KEY
-  - notContains:
-      path: spec.template.spec.containers[0].env
-      content:
-        name: RW_LICENSE_KEY_PATH
-      any: true
-  - notContains:
-      path: spec.template.spec.containers[0].volumeMounts
-      content:
-        name: license
-      any: true
-  - notContains:
-      path: spec.template.spec.volumes
-      content:
-        name: license
-      any: true
-- it: license key found with secret ref and key and passing by file
+- it: license key found with secret ref and key
   set:
     license:
       key: "ABC"
       secret:
         name: LICENSE-SECRET
         key: LICENSE-KEY
-      passAsFile: true
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1520,9 +1520,3 @@ license:
     ## @param key in the Secret. Defaults to "licenseKey".
     ##
     key: "licenseKey"
-
-  ## Deprecated. Will be removed once RisingWave v2.2 is released.
-  ## @param passAsFile Pass the license key as a file. Defaults to true.
-  ## Set it to false if you are deploying RisingWave < v2.1.
-  ##
-  passAsFile: true


### PR DESCRIPTION
**Motivation:**
The passAsFile parameter was redundant and added unnecessary complexity. Since passing the license as a file is now the default behavior starting from RisingWave v2.2, we can safely remove this parameter.

This close #126

**Changes:**
- Removed the passAsFile parameter from charts/risingwave/values.yaml
- Set license-related configuration by default in _helpers.tpl
- Removed all tests where passAsFile was set to false
- Removed passAsFile setup from tests where it was explicitly set to true

**Tests:**
- Verified using existing tests in charts/risingwave/tests via helm unittest
- Manually verified that the license is correctly set up in the pod container when starting a RisingWave cluster using Helm
![image](https://github.com/user-attachments/assets/80f611f3-f38f-4be7-91ff-a808417a07c0)
