### PR TITLE
fix: fix unexpected unregister-workers preStop hook issue when autoDeregistration is disabled

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.29
+version: 0.2.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/frontend-deploy.yaml
+++ b/charts/risingwave/templates/frontend-deploy.yaml
@@ -125,6 +125,7 @@ spec:
           --frontend-opts=--config-path /risingwave/config/risingwave.frontend.toml
             --listen-addr 0.0.0.0:{{ .Values.ports.frontend.svc }}
             --advertise-addr $(POD_IP):{{ .Values.ports.frontend.svc }}
+        {{- if .Values.frontendComponent.autoDeregistration.enabled }}
         lifecycle:
           preStop:
             exec:
@@ -134,6 +135,7 @@ spec:
               - >-
                 /risingwave/bin/risingwave ctl meta unregister-workers --yes \
                   --workers ${POD_IP}:{{ .Values.ports.compute.svc }}
+        {{- end }}
         {{- else }}
         command:
         - /risingwave/bin/risingwave

--- a/charts/risingwave/tests/frontend_embedded_serving_test.yaml
+++ b/charts/risingwave/tests/frontend_embedded_serving_test.yaml
@@ -17,8 +17,12 @@ tests:
       value:
       - /risingwave/bin/risingwave
       - standalone
-- it: should have pre-stop lifecycle hook
+- it: should have pre-stop lifecycle hook when auto deregistration is enabled
   template: frontend-deploy.yaml
+  set:
+    frontendComponent:
+      autoDeregistration:
+          enabled: true
   asserts:
   - exists:
       path: spec.template.spec.containers[0].lifecycle.preStop
@@ -30,6 +34,15 @@ tests:
       - >-
         /risingwave/bin/risingwave ctl meta unregister-workers --yes \
           --workers ${POD_IP}:5688
+- it: shouldn't have pre-stop lifecycle hook when auto deregistration is disabled
+  template: frontend-deploy.yaml
+  set:
+    frontendComponent:
+      autoDeregistration:
+          enabled: false
+  asserts:
+  - notExists:
+      path: spec.template.spec.containers[0].lifecycle
 - it: compute node should set role to streaming
   template: compute-sts.yaml
   asserts:

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -974,6 +974,13 @@ frontendComponent:
   ##
   embeddedServing: false
 
+  ## @param autoDeregistration Auto-deregistration of frontend pods. If enabled, frontend pods will be
+  ## automatically deregistered from the meta store when they are deleted.
+  ##
+  autoDeregistration:
+    ## @param autoDeregistration.enabled Enable auto-deregistration.
+    enabled: false
+
   ## @param frontendComponent.configuration RisingWave configuration in toml or toml object.
   ## If specified, it will override the default configuration.
   ## Ref: https://github.com/risingwavelabs/risingwave/blob/main/src/config/example.toml

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -974,11 +974,13 @@ frontendComponent:
   ##
   embeddedServing: false
 
-  ## @param autoDeregistration Auto-deregistration of frontend pods. If enabled, frontend pods will be
-  ## automatically deregistered from the meta store when they are deleted.
+  ## @param frontendComponent.autoDeregistration Auto-deregistration of frontend pods. This will only be effective when
+  ## the embeddedServing is true. If enabled, frontend pods will be automatically deregistered from
+  ## the meta store when they are deleted.
   ##
   autoDeregistration:
-    ## @param autoDeregistration.enabled Enable auto-deregistration.
+    ## @param frontendComponent.autoDeregistration.enabled Enable auto-deregistration for frontend pods. This only applies
+    ## when embeddedServing is true.
     enabled: false
 
   ## @param frontendComponent.configuration RisingWave configuration in toml or toml object.


### PR DESCRIPTION
**Motivation:**
Previously, the preStop lifecycle hook for unregistering frontend workers was added even when autoDeregistration was disabled, leading to unexpected behavior. This PR ensures the preStop hook is only present when auto-deregistration is explicitly enabled.

This fix #176

**Changes:**

- Updated the Helm template (frontend-deploy.yaml) to conditionally add the preStop lifecycle hook only when frontendComponent.autoDeregistration.enabled is true.
- Enhanced values.yaml with a documented frontendComponent.autoDeregistration.enabled field (default: false).
- Improved unit tests:
  - Added a test to verify the preStop hook exists when auto-deregistration is enabled.
  - Added a test to verify the preStop hook does not exist when auto-deregistration is disabled.

**Tests:**
- Ran and updated Helm unit tests to cover both enabled and disabled scenarios for auto-deregistration.
- Verified that the preStop hook is only rendered when expected by creating the RW cluster locally.

**Other:**
Bumped the chart version to 0.2.30.