### PR TITLE
feat: support resource group for compute nodes in RisingWave Helm Chart

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.31
+version: 0.2.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -6,47 +6,44 @@ SPDX-License-Identifier: APACHE-2.0
 {{- if not .Values.standalone.enabled -}}
 {{- $resourceGroups := .Values.computeComponent.resourceGroups | default list }}
 {{- $hasGroups := gt (len $resourceGroups) 0 }}
-{{- $groups := ternary $resourceGroups (list (dict "name" "")) $hasGroups }}
-{{/* Validate resource name uniqueness */}}
+{{- $defaultGroup := dict "name" "default" }}
+{{- $allGroups := list $defaultGroup }}
 {{- if $hasGroups }}
   {{- $nameMap := dict }}
+  {{- $_ := set $nameMap "default" true }}
   {{- range $group := $resourceGroups }}
     {{- $name := $group.name | default "" }}
     {{- if eq $name "" }}
       {{- fail "Each resource group must have a non-empty name." }}
     {{- end }}
-    {{- if eq $name "default" }}
-      {{- fail "Resource group name 'default' is not allowed." }}
-    {{- end }}
     {{- if hasKey $nameMap $name }}
       {{- fail (printf "Duplicate resource group name: '%s'" $name) }}
     {{- end }}
     {{- $_ := set $nameMap $name true }}
+    {{- $allGroups = append $allGroups $group }}
   {{- end }}
 {{- end }}
-{{- range $index, $group := $groups }}
+{{- range $index, $group := $allGroups }}
   {{- $ctx := deepCopy $ }}
   {{- $comp := dict }}
   {{- range $k, $v := $.Values.computeComponent }}
     {{- $_ := set $comp $k $v }}
   {{- end }}
-  {{- if $hasGroups }}
+  {{- if ne $group.name "default" }}
     {{- range $k, $v := $group }}
       {{- $_ := set $comp $k $v }}
     {{- end }}
-    {{- $_ := set $ctx.Values "computeComponent" $comp }}
-    {{- $_ := set $ctx.Values.computeComponent "resourceGroupName" $group.name }}
-  {{- else }}
-    {{- $_ := set $ctx.Values "computeComponent" $comp }}
   {{- end }}
+  {{- $_ := set $ctx.Values "computeComponent" $comp }}
+  {{- $_ := set $ctx.Values.computeComponent "resourceGroupName" $group.name }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "risingwave.computeComponentName" $ctx }}{{- if $hasGroups }}-{{ $group.name }}{{- end }}
+  name: {{ include "risingwave.computeComponentName" $ctx }}{{- if ne $group.name "default" }}-{{ $group.name }}{{- end }}
   labels:
     {{- include "risingwave.labels" $ctx | nindent 4 }}
     risingwave.risingwavelabs.com/component: compute
-    {{- if $hasGroups }}
+    {{- if ne $group.name "default" }}
     risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
     {{- end }}
   {{- $annotations := (include "risingwave.annotations" $ctx ) | trim }}
@@ -62,7 +59,7 @@ spec:
     matchLabels:
       {{- include "risingwave.selectorLabels" $ctx | nindent 6 }}
       risingwave.risingwavelabs.com/component: compute
-      {{- if $hasGroups }}
+      {{- if ne $group.name "default" }}
       risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
       {{- end }}
   serviceName: {{ include "risingwave.computeHeadlessServiceName" $ctx }}
@@ -87,7 +84,7 @@ spec:
         risingwave.risingwavelabs.com/component: compute
         risingwave/name: {{ include "risingwave.fullname" $ctx }}
         risingwave/component: compute
-        {{- if $hasGroups }}
+        {{- if ne $group.name "default" }}
         risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
         {{- end }}
         {{- if $comp.podLabels }}
@@ -212,7 +209,7 @@ spec:
             name: {{ $credentialsSecret }}
         {{- end }}
         env:
-        {{- if $hasGroups }}
+        {{- if ne $group.name "default" }}
         - name: RW_RESOURCE_GROUP
           value: "{{ $group.name }}"
         {{- end }}
@@ -485,7 +482,7 @@ spec:
       {{- if $comp.additionalContainers }}
       {{- toYaml $comp.additionalContainers | nindent 6 }}
       {{- end }}
-  {{- if and $hasGroups (lt $index (sub (len $groups) 1)) }}
+  {{- if and $hasGroups (lt $index (sub (len $allGroups) 1)) }}
 ---
   {{- end }}
 {{- end }}

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -7,6 +7,23 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $resourceGroups := .Values.computeComponent.resourceGroups | default list }}
 {{- $hasGroups := gt (len $resourceGroups) 0 }}
 {{- $groups := ternary $resourceGroups (list (dict "name" "")) $hasGroups }}
+{{/* Validate resource name uniqueness */}}
+{{- if $hasGroups }}
+  {{- $nameMap := dict }}
+  {{- range $group := $resourceGroups }}
+    {{- $name := $group.name | default "" }}
+    {{- if eq $name "" }}
+      {{- fail "Each resource group must have a non-empty name." }}
+    {{- end }}
+    {{- if eq $name "default" }}
+      {{- fail "Resource group name 'default' is not allowed." }}
+    {{- end }}
+    {{- if hasKey $nameMap $name }}
+      {{- fail (printf "Duplicate resource group name: '%s'" $name) }}
+    {{- end }}
+    {{- $_ := set $nameMap $name true }}
+  {{- end }}
+{{- end }}
 {{- range $index, $group := $groups }}
   {{- $ctx := deepCopy $ }}
   {{- $comp := dict }}

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -4,6 +4,338 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if not .Values.standalone.enabled -}}
+{{- $resourceGroups := .Values.computeComponent.resourceGroups | default list }}
+{{- if $resourceGroups and (gt (len $resourceGroups) 0) }}
+  {{- range $group := $resourceGroups }}
+    {{- $ctx := deepCopy $ }}
+    {{- $_ := set $ctx "resourceGroup" $group }}
+    {{- /* Inherit fields from computeComponent unless overridden in group */ -}}
+    {{- $comp := dict }}
+    {{- range $k, $v := $.Values.computeComponent }}
+      {{- $_ := set $comp $k $v }}
+    {{- end }}
+    {{- range $k, $v := $group }}
+      {{- $_ := set $comp $k $v }}
+    {{- end }}
+    {{- $_ := set $ctx.Values "computeComponent" $comp }}
+    {{- $_ := set $ctx.Values.computeComponent "resourceGroupName" $group.name }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "risingwave.computeComponentName" $ctx }}-{{ $group.name }}
+  labels:
+    {{- include "risingwave.labels" $ctx | nindent 4 }}
+    risingwave.risingwavelabs.com/component: compute
+    risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
+  {{- $annotations := (include "risingwave.annotations" $ctx ) | trim }}
+  {{- if $annotations }}
+  annotations:
+    {{ nindent 4 $annotations }}
+  {{- end }}
+spec:
+  {{- if not $comp.autoscaling.enabled }}
+  replicas: {{ $comp.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "risingwave.selectorLabels" $ctx | nindent 6 }}
+      risingwave.risingwavelabs.com/component: compute
+      risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
+  serviceName: {{ include "risingwave.computeHeadlessServiceName" $ctx }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "100%"
+  podManagementPolicy: Parallel
+  minReadySeconds: 0
+  {{- if $comp.volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- toYaml $comp.volumeClaimTemplates | nindent 2 }}
+  {{- end }}
+  {{- if $comp.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+  {{- toYaml $comp.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "risingwave.selectorLabels" $ctx | nindent 8 }}
+        risingwave.risingwavelabs.com/component: compute
+        risingwave/name: {{ include "risingwave.fullname" $ctx }}
+        risingwave/component: compute
+        risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
+        {{- if $comp.podLabels }}
+        {{- toYaml $comp.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if $ctx.Values.monitor.annotations.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ $ctx.Values.ports.compute.metrics }}"
+        prometheus.io/path: "/metrics"
+        {{- end }}
+        {{- include "risingwave.annotations" $ctx | nindent 8 }}
+        {{- if $comp.podAnnotations }}
+        {{- toYaml $comp.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- include "risingwave.computeConfigHashAnnotation" $ctx | nindent 8 }}
+        {{- if $ctx.Values.compactMode.enabled }}
+        {{- include "risingwave.frontendConfigHashAnnotation" $ctx | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if $ctx.Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $ctx.Values.image.pullSecrets }}
+      - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "risingwave.configurationConfigMapName" $ctx }}
+      {{- if and $ctx.Values.compactMode.enabled $ctx.Values.tls.existingSecretName }}
+      - name: certs
+        secret:
+          secretName: {{ $ctx.Values.tls.existingSecretName }}
+      {{- end }}
+      {{- if $comp.extraVolumes }}
+      {{- toYaml $comp.extraVolumes | nindent 6 }}
+      {{- end }}
+      restartPolicy: Always
+      {{- if $comp.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $comp.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if $comp.nodeSelector }}
+      nodeSelector:
+      {{- toYaml $comp.nodeSelector | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "risingwave.serviceAccountName" $ctx }}
+      automountServiceAccountToken: true
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      {{- if $comp.shareProcessNamespace }}
+      shareProcessNamespace: {{ $comp.shareProcessNamespace }}
+      {{- end }}
+      {{- if $comp.podSecurityContext }}
+      securityContext: {{- toYaml $comp.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if $comp.affinity }}
+      affinity: {{- toYaml $comp.affinity | nindent 8 }}
+      {{- end }}
+      {{- if $comp.schedulerName }}
+      schedulerName: {{ $comp.schedulerName }}
+      {{- end }}
+      {{- if $comp.tolerations }}
+      tolerations: {{- toYaml $comp.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if $comp.priorityClassName }}
+      priorityClassName: {{ $comp.priorityClassName }}
+      {{- end }}
+      {{- if $comp.runtimeClassName }}
+      runtimeClassName: {{ $comp.runtimeClassName }}
+      {{- end }}
+      enableServiceLinks: false
+      preemptionPolicy: PreemptLowerPriority
+      setHostnameAsFQDN: false
+      containers:
+      - name: compute
+        image: {{ include "risingwave.image" $ctx }}
+        imagePullPolicy: {{ $ctx.Values.image.pullPolicy }}
+        {{- if $ctx.Values.diagnosticMode.enabled }}
+        command: {{ toYaml $ctx.Values.diagnosticMode.command | nindent 8 }}
+        args: {{ toYaml $ctx.Values.diagnosticMode.args | nindent 8 }}
+        {{- else }}
+        command:
+        - /risingwave/bin/risingwave
+        - compute-node
+        {{- if $ctx.Values.frontendComponent.embeddedServing }}
+        args:
+        - --role=streaming
+        {{- end }}
+        {{- if $comp.autoDeregistration.enabled }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - bash
+              - -c
+              - >-
+                /risingwave/bin/risingwave ctl meta unregister-workers --yes \
+                  --workers ${POD_NAME}.{{ include "risingwave.computeHeadlessServiceName" $ctx }}.{{$.Release.Namespace}}.svc:{{ $ctx.Values.ports.compute.svc }}
+        {{- end }}
+        {{- end }}
+        ports:
+        - containerPort: {{ $ctx.Values.ports.compute.svc }}
+          name: svc
+          protocol: TCP
+        - containerPort: {{ $ctx.Values.ports.compute.metrics }}
+          name: metrics
+          protocol: TCP
+        envFrom:
+        {{- if $comp.extraEnvVarsConfigMap }}
+        - configMapRef:
+            name: {{ $comp.extraEnvVarsConfigMap }}
+        {{- end }}
+        {{- if $comp.extraEnvVarsSecret }}
+        - secretRef:
+            name: {{ $comp.extraEnvVarsSecret }}
+        {{- end }}
+        {{- $credentialsSecret := (include "risingwave.credentialsSecretName" $ctx ) -}}
+        {{- if $credentialsSecret }}
+        - secretRef:
+            name: {{ $credentialsSecret }}
+        {{- end }}
+        env:
+        - name: RW_RESOURCE_GROUP
+          value: "{{ $group.name }}"
+        {{ include "risingwave.cloudEnvironments" $ctx | nindent 8 }}
+        # Disable auto region loading. Refer to the original source for more information.
+        # https://github.com/awslabs/aws-sdk-rust/blob/main/sdk/aws-config/src/imds/region.rs
+        - name: AWS_EC2_METADATA_DISABLED
+          value: "true"
+        - name: RUST_LOG
+          value: {{ $comp.rustLog }}
+        - name: RUST_BACKTRACE
+          value: {{ $comp.rustBacktrace }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: "status.podIP"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.name"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.namespace"
+        - name: CONTAINER_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: "limits.cpu"
+        - name: CONTAINER_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: "limits.memory"
+        - name: RUST_MIN_STACK
+          value: "4194304"
+        {{- if $ctx.Values.stateStore.s3.enabled }}
+        - name: AWS_REGION
+          value: {{ $ctx.Values.stateStore.s3.region }}
+        {{- end }}  
+        {{- if and $ctx.Values.stateStore.s3.enabled $ctx.Values.stateStore.s3.forcePathStyle }} 
+        - name: RW_IS_FORCE_PATH_STYLE
+          value: 'true'
+        {{- end }}
+        {{- if $ctx.Values.stateStore.oss.enabled }}
+        - name: OSS_REGION
+          value: {{ $ctx.Values.stateStore.oss.region }}
+        {{- end }}
+        {{- if $ctx.Values.stateStore.obs.enabled }}
+        - name: OBS_REGION
+          value: {{ $ctx.Values.stateStore.obs.region }}
+        {{- end }}
+        {{- if (include "risingwave.bundle.minio.enabled" $ctx) }}
+        - name: MINIO_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: root-user
+              name: {{ default (include "common.names.fullname" $ctx.Subcharts.minio) $ctx.Values.minio.auth.existingSecret }}
+        - name: MINIO_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: root-password
+              name: {{ default (include "common.names.fullname" $ctx.Subcharts.minio) $ctx.Values.minio.auth.existingSecret }}
+        {{- end }}
+        {{- if $ctx.Values.stateStore.s3.enabled }}
+        {{- if $ctx.Values.stateStore.s3.endpoint }}
+        - name: RW_S3_ENDPOINT
+          value: {{ $ctx.Values.stateStore.s3.endpoint }}
+        {{- end }}
+        {{- else if $ctx.Values.stateStore.oss.enabled }}
+        - name: OSS_ENDPOINT
+          value: {{ include "risingwave.oss.endpoint" $ctx }}
+        {{- else if $ctx.Values.stateStore.obs.enabled }}
+        - name: OBS_ENDPOINT
+          value: {{ include "risingwave.obs.endpoint" $ctx }}
+        {{- else if $ctx.Values.stateStore.azblob.enabled }}
+        - name: AZBLOB_ENDPOINT
+          value: {{ $ctx.Values.stateStore.azblob.endpoint }}
+        {{- end }}
+        - name: RW_CONFIG_PATH
+          value: /risingwave/config/risingwave.compute.toml
+        - name: RW_LISTEN_ADDR
+          value: "0.0.0.0:{{ $ctx.Values.ports.compute.svc }}"
+        - name: RW_ADVERTISE_ADDR
+          value: "$(POD_IP):{{ $ctx.Values.ports.compute.svc }}"
+        {{- else }}
+          value: "$(POD_NAME).{{ include "risingwave.computeHeadlessServiceName" $ctx }}.$(POD_NAMESPACE).svc:{{ $ctx.Values.ports.compute.svc }}"
+        {{- end }}
+        - name: RW_PROMETHEUS_LISTENER_ADDR
+          value: "0.0.0.0:{{ $ctx.Values.ports.compute.metrics }}"
+        - name: RW_META_ADDR
+          value: {{ printf "load-balance+http://%s.%s.svc:%d" (include "risingwave.metaHeadlessServiceName" $ctx) $ctx.Release.Namespace ($ctx.Values.ports.meta.svc | int)}}
+        - name: RW_STATE_STORE
+          value: {{ include "risingwave.hummockConnectionString" $ctx }}
+        - name: RW_DATA_DIRECTORY
+          value: {{ include "risingwave.stateStoreDataDirectory" $ctx }}
+        {{- if $comp.resources.limits }}
+        {{- if $comp.resources.limits.cpu }}
+        - name: RW_PARALLELISM
+          value: $(CONTAINER_CPU_LIMIT)
+        {{- end }}
+        {{- if $comp.resources.limits.memory }}
+        - name: RW_TOTAL_MEMORY_BYTES
+          value: $(CONTAINER_MEMORY_LIMIT)
+        {{- end }}
+        {{- end }}
+        {{- if $comp.extraEnvVars }}
+        {{- $comp.extraEnvVars | toYaml | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- if $comp.resources.limits }}
+          limits:
+            {{ toYaml $comp.resources.limits | nindent 12 }}
+          {{- end }}
+          {{- if $comp.resources.requests }}
+          requests:
+            {{ toYaml $comp.resources.requests | nindent 12 }}
+          {{- end }}
+        volumeMounts:
+        - mountPath: /risingwave/config
+          name: config
+          readOnly: true
+        {{- if $comp.extraVolumeMounts }}
+        {{- toYaml $comp.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if $comp.securityContext }}
+        securityContext: {{ toYaml $comp.securityContext | nindent 10 }}
+        {{- end }}
+        {{- if not $ctx.Values.diagnosticMode.enabled }}
+        startupProbe:
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 12
+          tcpSocket:
+            port: svc
+        livenessProbe:
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          tcpSocket:
+            port: svc
+        readinessProbe:
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          tcpSocket:
+            port: svc
+        {{- end }}
+      {{- if $comp.additionalContainers }}
+      {{- toYaml $comp.additionalContainers | nindent 6 }}
+      {{- end }}
+  {{- end }}
+{{- else }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -5,8 +5,9 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- if not .Values.standalone.enabled -}}
 {{- $resourceGroups := .Values.computeComponent.resourceGroups | default list }}
-{{- if $resourceGroups and (gt (len $resourceGroups) 0) }}
-  {{- range $group := $resourceGroups }}
+{{- if gt (len $resourceGroups) 0 }}
+  {{- $count := len $resourceGroups }}
+  {{- range $index, $group := $resourceGroups }}
     {{- $ctx := deepCopy $ }}
     {{- $_ := set $ctx "resourceGroup" $group }}
     {{- /* Inherit fields from computeComponent unless overridden in group */ -}}
@@ -19,7 +20,6 @@ SPDX-License-Identifier: APACHE-2.0
     {{- end }}
     {{- $_ := set $ctx.Values "computeComponent" $comp }}
     {{- $_ := set $ctx.Values.computeComponent "resourceGroupName" $group.name }}
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -268,6 +268,7 @@ spec:
         - name: RW_LISTEN_ADDR
           value: "0.0.0.0:{{ $ctx.Values.ports.compute.svc }}"
         - name: RW_ADVERTISE_ADDR
+        {{- if $comp.advertisingWithIP }}
           value: "$(POD_IP):{{ $ctx.Values.ports.compute.svc }}"
         {{- else }}
           value: "$(POD_NAME).{{ include "risingwave.computeHeadlessServiceName" $ctx }}.$(POD_NAMESPACE).svc:{{ $ctx.Values.ports.compute.svc }}"
@@ -334,6 +335,9 @@ spec:
       {{- if $comp.additionalContainers }}
       {{- toYaml $comp.additionalContainers | nindent 6 }}
       {{- end }}
+    {{- if lt $index (sub $count 1) }}
+---
+    {{- end }}
   {{- end }}
 {{- else }}
 apiVersion: apps/v1
@@ -769,4 +773,5 @@ spec:
       {{- if .Values.computeComponent.additionalContainers }}
       {{- toYaml .Values.computeComponent.additionalContainers | nindent 6 }}
       {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -211,7 +211,7 @@ spec:
         env:
         {{- if ne $group.name "default" }}
         - name: RW_RESOURCE_GROUP
-          value: "{{ $group.name }}"
+          value: {{ $group.name | quote }}
         {{- end }}
         {{ include "risingwave.cloudEnvironments" $ctx | nindent 8 }}
         # Disable auto region loading. Refer to the original source for more information.

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -5,29 +5,33 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- if not .Values.standalone.enabled -}}
 {{- $resourceGroups := .Values.computeComponent.resourceGroups | default list }}
-{{- if gt (len $resourceGroups) 0 }}
-  {{- $count := len $resourceGroups }}
-  {{- range $index, $group := $resourceGroups }}
-    {{- $ctx := deepCopy $ }}
-    {{- $_ := set $ctx "resourceGroup" $group }}
-    {{- /* Inherit fields from computeComponent unless overridden in group */ -}}
-    {{- $comp := dict }}
-    {{- range $k, $v := $.Values.computeComponent }}
-      {{- $_ := set $comp $k $v }}
-    {{- end }}
+{{- $hasGroups := gt (len $resourceGroups) 0 }}
+{{- $groups := ternary $resourceGroups (list (dict "name" "")) $hasGroups }}
+{{- range $index, $group := $groups }}
+  {{- $ctx := deepCopy $ }}
+  {{- $comp := dict }}
+  {{- range $k, $v := $.Values.computeComponent }}
+    {{- $_ := set $comp $k $v }}
+  {{- end }}
+  {{- if $hasGroups }}
     {{- range $k, $v := $group }}
       {{- $_ := set $comp $k $v }}
     {{- end }}
     {{- $_ := set $ctx.Values "computeComponent" $comp }}
     {{- $_ := set $ctx.Values.computeComponent "resourceGroupName" $group.name }}
+  {{- else }}
+    {{- $_ := set $ctx.Values "computeComponent" $comp }}
+  {{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "risingwave.computeComponentName" $ctx }}-{{ $group.name }}
+  name: {{ include "risingwave.computeComponentName" $ctx }}{{- if $hasGroups }}-{{ $group.name }}{{- end }}
   labels:
     {{- include "risingwave.labels" $ctx | nindent 4 }}
     risingwave.risingwavelabs.com/component: compute
+    {{- if $hasGroups }}
     risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
+    {{- end }}
   {{- $annotations := (include "risingwave.annotations" $ctx ) | trim }}
   {{- if $annotations }}
   annotations:
@@ -41,7 +45,9 @@ spec:
     matchLabels:
       {{- include "risingwave.selectorLabels" $ctx | nindent 6 }}
       risingwave.risingwavelabs.com/component: compute
+      {{- if $hasGroups }}
       risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
+      {{- end }}
   serviceName: {{ include "risingwave.computeHeadlessServiceName" $ctx }}
   updateStrategy:
     type: RollingUpdate
@@ -64,7 +70,9 @@ spec:
         risingwave.risingwavelabs.com/component: compute
         risingwave/name: {{ include "risingwave.fullname" $ctx }}
         risingwave/component: compute
+        {{- if $hasGroups }}
         risingwave.risingwavelabs.com/resource-group: {{ $group.name }}
+        {{- end }}
         {{- if $comp.podLabels }}
         {{- toYaml $comp.podLabels | nindent 8 }}
         {{- end }}
@@ -187,8 +195,10 @@ spec:
             name: {{ $credentialsSecret }}
         {{- end }}
         env:
+        {{- if $hasGroups }}
         - name: RW_RESOURCE_GROUP
           value: "{{ $group.name }}"
+        {{- end }}
         {{ include "risingwave.cloudEnvironments" $ctx | nindent 8 }}
         # Disable auto region loading. Refer to the original source for more information.
         # https://github.com/awslabs/aws-sdk-rust/blob/main/sdk/aws-config/src/imds/region.rs
@@ -332,359 +342,44 @@ spec:
           tcpSocket:
             port: svc
         {{- end }}
-      {{- if $comp.additionalContainers }}
-      {{- toYaml $comp.additionalContainers | nindent 6 }}
-      {{- end }}
-    {{- if lt $index (sub $count 1) }}
----
-    {{- end }}
-  {{- end }}
-{{- else }}
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: {{ include "risingwave.computeComponentName" . }}
-  labels:
-    {{- include "risingwave.labels" . | nindent 4 }}
-    risingwave.risingwavelabs.com/component: compute
-  {{- $annotations := (include "risingwave.annotations" . ) | trim }}
-  {{- if $annotations }}
-  annotations:
-    {{ nindent 4 $annotations }}
-  {{- end }}
-spec:
-  {{- if not .Values.computeComponent.autoscaling.enabled }}
-  replicas: {{ .Values.computeComponent.replicas }}
-  {{- end }}
-  selector:
-    matchLabels:
-      {{- include "risingwave.selectorLabels" . | nindent 6 }}
-      risingwave.risingwavelabs.com/component: compute
-  serviceName: {{ include "risingwave.computeHeadlessServiceName" . }}
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: "100%"
-  podManagementPolicy: Parallel
-  minReadySeconds: 0
-  {{- if .Values.computeComponent.volumeClaimTemplates }}
-  volumeClaimTemplates:
-  {{- toYaml .Values.computeComponent.volumeClaimTemplates | nindent 2 }}
-  {{- end }}
-  {{- if .Values.computeComponent.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy:
-  {{- toYaml .Values.computeComponent.persistentVolumeClaimRetentionPolicy | nindent 4 }}
-  {{- end }}
-  template:
-    metadata:
-      labels:
-        {{- include "risingwave.selectorLabels" . | nindent 8 }}
-        risingwave.risingwavelabs.com/component: compute
-        risingwave/name: {{ include "risingwave.fullname" . }}
-        risingwave/component: compute
-        {{- if .Values.computeComponent.podLabels }}
-        {{- toYaml .Values.computeComponent.podLabels | nindent 8 }}
-        {{- end }}
-      annotations:
-        {{- if .Values.monitor.annotations.enabled }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.ports.compute.metrics }}"
-        prometheus.io/path: "/metrics"
-        {{- end }}
-        {{- include "risingwave.annotations" . | nindent 8 }}
-        {{- if .Values.computeComponent.podAnnotations }}
-        {{- toYaml .Values.computeComponent.podAnnotations | nindent 8 }}
-        {{- end }}
-        {{- include "risingwave.computeConfigHashAnnotation" . | nindent 8 }}
-        {{- if .Values.compactMode.enabled }}
-        {{- include "risingwave.frontendConfigHashAnnotation" . | nindent 8 }}
-        {{- end }}
-    spec:
-      {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-      - name: {{ . }}
-      {{- end }}
-      {{- end }}
-      volumes:
-      - name: config
-        configMap:
-          name: {{ include "risingwave.configurationConfigMapName" . }}
-      {{- if and .Values.compactMode.enabled .Values.tls.existingSecretName }}
-      - name: certs
-        secret:
-          secretName: {{ .Values.tls.existingSecretName }}
-      {{- end }}
-      {{- if .Values.computeComponent.extraVolumes }}
-      {{- toYaml .Values.computeComponent.extraVolumes | nindent 6 }}
-      {{- end }}
-      restartPolicy: Always
-      {{- if .Values.computeComponent.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.computeComponent.terminationGracePeriodSeconds }}
-      {{- end }}
-      {{- if .Values.computeComponent.nodeSelector }}
-      nodeSelector:
-      {{- toYaml .Values.computeComponent.nodeSelector | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "risingwave.serviceAccountName" . }}
-      automountServiceAccountToken: true
-      hostNetwork: false
-      hostPID: false
-      hostIPC: false
-      {{- if .Values.computeComponent.shareProcessNamespace }}
-      shareProcessNamespace: {{ .Values.computeComponent.shareProcessNamespace }}
-      {{- end }}
-      {{- if .Values.computeComponent.podSecurityContext }}
-      securityContext: {{- toYaml .Values.computeComponent.podSecurityContext | nindent 8 }}
-      {{- end }}
-      {{- if .Values.computeComponent.affinity }}
-      affinity: {{- toYaml .Values.computeComponent.affinity | nindent 8 }}
-      {{- end }}
-      {{- if .Values.computeComponent.schedulerName }}
-      schedulerName: {{ .Values.computeComponent.schedulerName }}
-      {{- end }}
-      {{- if .Values.computeComponent.tolerations }}
-      tolerations: {{- toYaml .Values.computeComponent.tolerations | nindent 8 }}
-      {{- end }}
-      {{- if .Values.computeComponent.priorityClassName }}
-      priorityClassName: {{ .Values.computeComponent.priorityClassName }}
-      {{- end }}
-      {{- if .Values.computeComponent.runtimeClassName }}
-      runtimeClassName: {{ .Values.computeComponent.runtimeClassName }}
-      {{- end }}
-      enableServiceLinks: false
-      preemptionPolicy: PreemptLowerPriority
-      setHostnameAsFQDN: false
-      containers:
-      - name: compute
-        image: {{ include "risingwave.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.diagnosticMode.enabled }}
-        command: {{ toYaml .Values.diagnosticMode.command | nindent 8 }}
-        args: {{ toYaml .Values.diagnosticMode.args | nindent 8 }}
-        {{- else }}
-        command:
-        - /risingwave/bin/risingwave
-        - compute-node
-        {{- if .Values.frontendComponent.embeddedServing }}
-        args:
-        - --role=streaming
-        {{- end }}
-        {{- if .Values.computeComponent.autoDeregistration.enabled }}
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - bash
-              - -c
-              - >-
-                /risingwave/bin/risingwave ctl meta unregister-workers --yes \
-                  --workers ${POD_NAME}.{{ include "risingwave.computeHeadlessServiceName" . }}.{{.Release.Namespace}}.svc:{{ .Values.ports.compute.svc }}
-        {{- end }}
-        {{- end }}
-        ports:
-        - containerPort: {{ .Values.ports.compute.svc }}
-          name: svc
-          protocol: TCP
-        - containerPort: {{ .Values.ports.compute.metrics }}
-          name: metrics
-          protocol: TCP
-        envFrom:
-        {{- if .Values.computeComponent.extraEnvVarsConfigMap }}
-        - configMapRef:
-            name: {{ .Values.computeComponent.extraEnvVarsConfigMap }}
-        {{- end }}
-        {{- if .Values.computeComponent.extraEnvVarsSecret }}
-        - secretRef:
-            name: {{ .Values.computeComponent.extraEnvVarsSecret }}
-        {{- end }}
-        {{- $credentialsSecret := (include "risingwave.credentialsSecretName" . ) -}}
-        {{- if $credentialsSecret }}
-        - secretRef:
-            name: {{ $credentialsSecret }}
-        {{- end }}
-        env:
-        {{ include "risingwave.cloudEnvironments" . | nindent 8 }}
-        # Disable auto region loading. Refer to the original source for more information.
-        # https://github.com/awslabs/aws-sdk-rust/blob/main/sdk/aws-config/src/imds/region.rs
-        - name: AWS_EC2_METADATA_DISABLED
-          value: "true"
-        - name: RUST_LOG
-          value: {{ .Values.computeComponent.rustLog }}
-        - name: RUST_BACKTRACE
-          value: {{ .Values.computeComponent.rustBacktrace }}
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: "status.podIP"
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: "metadata.name"
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: "metadata.namespace"
-        - name: CONTAINER_CPU_LIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: "limits.cpu"
-        - name: CONTAINER_MEMORY_LIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: "limits.memory"
-        - name: RUST_MIN_STACK
-          value: "4194304"
-        {{- if .Values.stateStore.s3.enabled }}
-        - name: AWS_REGION
-          value: {{ .Values.stateStore.s3.region }}
-        {{- end }}  
-        {{- if and .Values.stateStore.s3.enabled .Values.stateStore.s3.forcePathStyle }} 
-        - name: RW_IS_FORCE_PATH_STYLE
-          value: 'true'
-        {{- end }}
-        {{- if .Values.stateStore.oss.enabled }}
-        - name: OSS_REGION
-          value: {{ .Values.stateStore.oss.region }}
-        {{- end }}
-        {{- if .Values.stateStore.obs.enabled }}
-        - name: OBS_REGION
-          value: {{ .Values.stateStore.obs.region }}
-        {{- end }}
-        {{- if (include "risingwave.bundle.minio.enabled" .) }}
-        - name: MINIO_USERNAME
-          valueFrom:
-            secretKeyRef:
-              key: root-user
-              name: {{ default (include "common.names.fullname" .Subcharts.minio) .Values.minio.auth.existingSecret }}
-        - name: MINIO_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: root-password
-              name: {{ default (include "common.names.fullname" .Subcharts.minio) .Values.minio.auth.existingSecret }}
-        {{- end }}
-        {{- if .Values.stateStore.s3.enabled }}
-        {{- if .Values.stateStore.s3.endpoint }}
-        - name: RW_S3_ENDPOINT
-          value: {{ .Values.stateStore.s3.endpoint }}
-        {{- end }}
-        {{- else if .Values.stateStore.oss.enabled }}
-        - name: OSS_ENDPOINT
-          value: {{ include "risingwave.oss.endpoint" . }}
-        {{- else if .Values.stateStore.obs.enabled }}
-        - name: OBS_ENDPOINT
-          value: {{ include "risingwave.obs.endpoint" . }}
-        {{- else if .Values.stateStore.azblob.enabled }}
-        - name: AZBLOB_ENDPOINT
-          value: {{ .Values.stateStore.azblob.endpoint }}
-        {{- end }}
-        - name: RW_CONFIG_PATH
-          value: /risingwave/config/risingwave.compute.toml
-        - name: RW_LISTEN_ADDR
-          value: "0.0.0.0:{{ .Values.ports.compute.svc }}"
-        - name: RW_ADVERTISE_ADDR
-        {{- if .Values.computeComponent.advertisingWithIP }}
-          value: "$(POD_IP):{{ .Values.ports.compute.svc }}"
-        {{- else }}
-          value: "$(POD_NAME).{{ include "risingwave.computeHeadlessServiceName" . }}.$(POD_NAMESPACE).svc:{{ .Values.ports.compute.svc }}"
-        {{- end }}
-        - name: RW_PROMETHEUS_LISTENER_ADDR
-          value: "0.0.0.0:{{ .Values.ports.compute.metrics }}"
-        - name: RW_META_ADDR
-          value: {{ printf "load-balance+http://%s.%s.svc:%d" (include "risingwave.metaHeadlessServiceName" .) .Release.Namespace (.Values.ports.meta.svc | int)}}
-        - name: RW_STATE_STORE
-          value: {{ include "risingwave.hummockConnectionString" . }}
-        - name: RW_DATA_DIRECTORY
-          value: {{ include "risingwave.stateStoreDataDirectory" . }}
-        {{- if .Values.computeComponent.resources.limits }}
-        {{- if .Values.computeComponent.resources.limits.cpu }}
-        - name: RW_PARALLELISM
-          value: $(CONTAINER_CPU_LIMIT)
-        {{- end }}
-        {{- if .Values.computeComponent.resources.limits.memory }}
-        - name: RW_TOTAL_MEMORY_BYTES
-          value: $(CONTAINER_MEMORY_LIMIT)
-        {{- end }}
-        {{- end }}
-        {{- if .Values.computeComponent.extraEnvVars }}
-        {{- .Values.computeComponent.extraEnvVars | toYaml | nindent 8 }}
-        {{- end }}
-        resources:
-          {{- if .Values.computeComponent.resources.limits }}
-          limits:
-            {{ toYaml .Values.computeComponent.resources.limits | nindent 12 }}
-          {{- end }}
-          {{- if .Values.computeComponent.resources.requests }}
-          requests:
-            {{ toYaml .Values.computeComponent.resources.requests | nindent 12 }}
-          {{- end }}
-        volumeMounts:
-        - mountPath: /risingwave/config
-          name: config
-          readOnly: true
-        {{- if .Values.computeComponent.extraVolumeMounts }}
-        {{- toYaml .Values.computeComponent.extraVolumeMounts | nindent 8 }}
-        {{- end }}
-        {{- if .Values.computeComponent.securityContext }}
-        securityContext: {{ toYaml .Values.computeComponent.securityContext | nindent 10 }}
-        {{- end }}
-        {{- if not .Values.diagnosticMode.enabled }}
-        startupProbe:
-          initialDelaySeconds: 2
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 12
-          tcpSocket:
-            port: svc
-        livenessProbe:
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          tcpSocket:
-            port: svc
-        readinessProbe:
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          tcpSocket:
-            port: svc
-        {{- end }}
-      {{- if .Values.compactMode.enabled }}
+      {{- if $ctx.Values.compactMode.enabled }}
       - name: frontend
-        image: {{ include "risingwave.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.diagnosticMode.enabled }}
-        command: {{ toYaml .Values.diagnosticMode.command | nindent 8 }}
-        args: {{ toYaml .Values.diagnosticMode.args | nindent 8 }}
+        image: {{ include "risingwave.image" $ctx }}
+        imagePullPolicy: {{ $ctx.Values.image.pullPolicy }}
+        {{- if $ctx.Values.diagnosticMode.enabled }}
+        command: {{ toYaml $ctx.Values.diagnosticMode.command | nindent 8 }}
+        args: {{ toYaml $ctx.Values.diagnosticMode.args | nindent 8 }}
         {{- else }}
         command:
         - /risingwave/bin/risingwave
         - frontend-node
         {{- end }}
         ports:
-        - containerPort: {{ .Values.ports.frontend.svc }}
+        - containerPort: {{ $ctx.Values.ports.frontend.svc }}
           name: f-svc
           protocol: TCP
-        - containerPort: {{ .Values.ports.frontend.metrics }}
+        - containerPort: {{ $ctx.Values.ports.frontend.metrics }}
           name: f-metrics
           protocol: TCP
         envFrom:
-        {{- if .Values.frontendComponent.extraEnvVarsConfigMap }}
+        {{- if $ctx.Values.frontendComponent.extraEnvVarsConfigMap }}
         - configMapRef:
-            name: {{ .Values.frontendComponent.extraEnvVarsConfigMap }}
+            name: {{ $ctx.Values.frontendComponent.extraEnvVarsConfigMap }}
         {{- end }}
-        {{- if .Values.frontendComponent.extraEnvVarsSecret }}
+        {{- if $ctx.Values.frontendComponent.extraEnvVarsSecret }}
         - secretRef:
-            name: {{ .Values.frontendComponent.extraEnvVarsSecret }}
+            name: {{ $ctx.Values.frontendComponent.extraEnvVarsSecret }}
         {{- end }}
         env:
-        {{ include "risingwave.cloudEnvironments" . | nindent 8 }}
+        {{ include "risingwave.cloudEnvironments" $ctx | nindent 8 }}
         # Disable auto region loading. Refer to the original source for more information.
         # https://github.com/awslabs/aws-sdk-rust/blob/main/sdk/aws-config/src/imds/region.rs
         - name: AWS_EC2_METADATA_DISABLED
           value: "true"
         - name: RUST_LOG
-          value: {{ .Values.frontendComponent.rustLog }}
+          value: {{ $ctx.Values.frontendComponent.rustLog }}
         - name: RUST_BACKTRACE
-          value: {{ .Values.frontendComponent.rustBacktrace }}
+          value: {{ $ctx.Values.frontendComponent.rustBacktrace }}
         - name: POD_IP
           valueFrom:
             fieldRef:
@@ -710,47 +405,47 @@ spec:
         - name: RW_CONFIG_PATH
           value: /risingwave/config/risingwave.frontend.toml
         - name: RW_LISTEN_ADDR
-          value: "0.0.0.0:{{ .Values.ports.frontend.svc }}"
+          value: "0.0.0.0:{{ $ctx.Values.ports.frontend.svc }}"
         - name: RW_ADVERTISE_ADDR
-          value: "$(POD_IP):{{ .Values.ports.frontend.svc }}"
+          value: "$(POD_IP):{{ $ctx.Values.ports.frontend.svc }}"
         - name: RW_PROMETHEUS_LISTENER_ADDR
-          value: "0.0.0.0:{{ .Values.ports.frontend.metrics }}"
+          value: "0.0.0.0:{{ $ctx.Values.ports.frontend.metrics }}"
         - name: RW_META_ADDR
-          value: {{ printf "load-balance+http://%s.%s.svc:%d" (include "risingwave.metaHeadlessServiceName" .) .Release.Namespace (.Values.ports.meta.svc | int)}}
-        {{- if .Values.tls.existingSecretName }}
+          value: {{ printf "load-balance+http://%s.%s.svc:%d" (include "risingwave.metaHeadlessServiceName" $ctx) $ctx.Release.Namespace ($ctx.Values.ports.meta.svc | int)}}
+        {{- if $ctx.Values.tls.existingSecretName }}
         - name: RW_SSL_CERT
           value: /risingwave/certs/tls.crt
         - name: RW_SSL_KEY
           value: /risingwave/certs/tls.key
         {{- end }}
-        {{- if .Values.frontendComponent.extraEnvVars }}
-        {{- .Values.frontendComponent.extraEnvVars | toYaml | nindent 8 }}
+        {{- if $ctx.Values.frontendComponent.extraEnvVars }}
+        {{- $ctx.Values.frontendComponent.extraEnvVars | toYaml | nindent 8 }}
         {{- end }}
         resources:
-          {{- if .Values.frontendComponent.resources.limits }}
+          {{- if $ctx.Values.frontendComponent.resources.limits }}
           limits:
-            {{ toYaml .Values.frontendComponent.resources.limits | nindent 12 }}
+            {{ toYaml $ctx.Values.frontendComponent.resources.limits | nindent 12 }}
           {{- end }}
-          {{- if .Values.frontendComponent.resources.requests }}
+          {{- if $ctx.Values.frontendComponent.resources.requests }}
           requests:
-            {{ toYaml .Values.frontendComponent.resources.requests | nindent 12 }}
+            {{ toYaml $ctx.Values.frontendComponent.resources.requests | nindent 12 }}
           {{- end }}
         volumeMounts:
         - mountPath: /risingwave/config
           name: config
           readOnly: true
-        {{- if .Values.tls.existingSecretName }}
+        {{- if $ctx.Values.tls.existingSecretName }}
         - mountPath: /risingwave/certs
           name: certs
           readOnly: true
         {{- end }}
-        {{- if .Values.frontendComponent.extraVolumeMounts }}
-        {{- toYaml .Values.frontendComponent.extraVolumeMounts | nindent 8 }}
+        {{- if $ctx.Values.frontendComponent.extraVolumeMounts }}
+        {{- toYaml $ctx.Values.frontendComponent.extraVolumeMounts | nindent 8 }}
         {{- end }}
-        {{- if .Values.frontendComponent.securityContext }}
-        securityContext: {{ toYaml .Values.frontendComponent.securityContext | nindent 10 }}
+        {{- if $ctx.Values.frontendComponent.securityContext }}
+        securityContext: {{ toYaml $ctx.Values.frontendComponent.securityContext | nindent 10 }}
         {{- end }}
-        {{- if not .Values.diagnosticMode.enabled }}
+        {{- if not $ctx.Values.diagnosticMode.enabled }}
         startupProbe:
           initialDelaySeconds: 2
           periodSeconds: 5
@@ -770,8 +465,11 @@ spec:
             port: f-svc
         {{- end }}
       {{- end }}
-      {{- if .Values.computeComponent.additionalContainers }}
-      {{- toYaml .Values.computeComponent.additionalContainers | nindent 6 }}
+      {{- if $comp.additionalContainers }}
+      {{- toYaml $comp.additionalContainers | nindent 6 }}
       {{- end }}
-{{- end -}}
+  {{- if and $hasGroups (lt $index (sub (len $groups) 1)) }}
+---
+  {{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -18,11 +18,9 @@ tests:
   - hasDocuments:
       count: 3
   - documentIndex: 0
-    containsDocument:
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: RELEASE-NAME-risingwave-compute. # Default resource group
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute # Default group
   - documentIndex: 0
     equal:
       path: spec.replicas
@@ -31,11 +29,9 @@ tests:
     notExists:
       path: spec.template.spec.containers[?(@.name=="RW_RESOURCE_GROUP")] 
   - documentIndex: 1
-    containsDocument:
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: RELEASE-NAME-risingwave-compute-group-a
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-group-a
   - documentIndex: 1
     equal:
       path: spec.replicas
@@ -50,14 +46,12 @@ tests:
       value: group-a
   - documentIndex: 2
     equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-group-b
+  - documentIndex: 2
+    equal:
       path: spec.replicas
       value: 5
-  - documentIndex: 2
-    containsDocument:
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: RELEASE-NAME-risingwave-compute-group-b
   - documentIndex: 2
     equal:
       path: spec.template.spec.containers[0].env[0].name

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -8,68 +8,64 @@ tests:
 - it: renders multiple StatefulSets for resource groups
   set:
     computeComponent:
+      replicas: 3
       resourceGroups:
         - name: group-a
           replicas: 2
         - name: group-b
           replicas: 5
-        - name: group-c
-          replicas: 6
   asserts:
+  - hasDocuments:
+      count: 3
   - documentIndex: 0
+    containsDocument:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: RELEASE-NAME-risingwave-compute. # Default resource group
+  - documentIndex: 0
+    equal:
+      path: spec.replicas
+      value: 3
+  - documentIndex: 0
+    notExists:
+      path: spec.template.spec.containers[?(@.name=="RW_RESOURCE_GROUP")] 
+  - documentIndex: 1
     containsDocument:
       apiVersion: apps/v1
       kind: StatefulSet
       metadata:
         name: RELEASE-NAME-risingwave-compute-group-a
   - documentIndex: 1
+    equal:
+      path: spec.replicas
+      value: 2
+  - documentIndex: 1
+    equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: RW_RESOURCE_GROUP
+  - documentIndex: 1    
+    equal:
+      path: spec.template.spec.containers[0].env[0].value
+      value: group-a
+  - documentIndex: 2
+    equal:
+      path: spec.replicas
+      value: 5
+  - documentIndex: 2
     containsDocument:
       apiVersion: apps/v1
       kind: StatefulSet
       metadata:
         name: RELEASE-NAME-risingwave-compute-group-b
   - documentIndex: 2
-    containsDocument:
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: RELEASE-NAME-risingwave-compute-group-c
-  - documentIndex: 0
-    equal:
-      path: spec.replicas
-      value: 2
-  - documentIndex: 1
-    equal:
-      path: spec.replicas
-      value: 5
-  - documentIndex: 2
-    equal:
-      path: spec.replicas
-      value: 6
-  - documentIndex: 0
     equal:
       path: spec.template.spec.containers[0].env[0].name
       value: RW_RESOURCE_GROUP
-  - documentIndex: 0
-    equal:
-      path: spec.template.spec.containers[0].env[0].value
-      value: group-a
-  - documentIndex: 1
-    equal:
-      path: spec.template.spec.containers[0].env[0].name
-      value: RW_RESOURCE_GROUP
-  - documentIndex: 1
+  - documentIndex: 2    
     equal:
       path: spec.template.spec.containers[0].env[0].value
       value: group-b
-  - documentIndex: 2
-    equal:
-      path: spec.template.spec.containers[0].env[0].name
-      value: RW_RESOURCE_GROUP
-  - documentIndex: 2
-    equal:
-      path: spec.template.spec.containers[0].env[0].value
-      value: group-c
 - it: falls back to old behavior if resourceGroups is empty
   set:
     computeComponent:
@@ -128,7 +124,7 @@ tests:
         - name: group-b
   asserts:
     - failedTemplate:
-        errorMessage: "Resource group name 'default' is not allowed."
+        errorMessage: "Duplicate resource group name: 'default'"
 - it: fails if resource group name is empty
   set:
     computeComponent:

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -12,66 +12,77 @@ tests:
         - name: group-a
           replicas: 2
         - name: group-b
-          replicas: 10
+          replicas: 5
+        - name: group-c
+          replicas: 6
   asserts:
-  - hasDocuments:
-      count: 2
-  - containsDocument:
+  - documentIndex: 0
+    containsDocument:
       apiVersion: apps/v1
       kind: StatefulSet
       metadata:
         name: RELEASE-NAME-risingwave-compute-group-a
-  - containsDocument:
+  - documentIndex: 1
+    containsDocument:
       apiVersion: apps/v1
       kind: StatefulSet
       metadata:
         name: RELEASE-NAME-risingwave-compute-group-b
-  - equal:
+  - documentIndex: 2
+    containsDocument:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: RELEASE-NAME-risingwave-compute-group-c
+  - documentIndex: 0
+    equal:
       path: spec.replicas
       value: 2
-      documentSelector:
-        metadata:
-          name: RELEASE-NAME-risingwave-compute-group-a
-  - equal:
+  - documentIndex: 1
+    equal:
       path: spec.replicas
-      value: 10
-      documentSelector:
-        metadata:
-          name: RELEASE-NAME-risingwave-compute-group-b
-  - equal:
+      value: 5
+  - documentIndex: 2
+    equal:
+      path: spec.replicas
+      value: 6
+  - documentIndex: 0
+    equal:
       path: spec.template.spec.containers[0].env[0].name
       value: RW_RESOURCE_GROUP
-      documentSelector:
-        metadata:
-          name: RELEASE-NAME-risingwave-compute-group-a
-  - equal:
+  - documentIndex: 0
+    equal:
       path: spec.template.spec.containers[0].env[0].value
       value: group-a
-      documentSelector:
-        metadata:
-          name: RELEASE-NAME-risingwave-compute-group-a
-  - equal:
+  - documentIndex: 1
+    equal:
       path: spec.template.spec.containers[0].env[0].name
       value: RW_RESOURCE_GROUP
-      documentSelector:
-        metadata:
-          name: RELEASE-NAME-risingwave-compute-group-b
-  - equal:
+  - documentIndex: 1
+    equal:
       path: spec.template.spec.containers[0].env[0].value
       value: group-b
-      documentSelector:
-        metadata:
-          name: RELEASE-NAME-risingwave-compute-group-b
-# - it: falls back to old behavior if resourceGroups is empty
-#   set:
-#     computeComponent:
-#       resourceGroups: []
-#       replicas: 3
-#   asserts:
-#   - hasDocuments:
-#       count: 1
-#   - equal:
-#       path: spec.replicas
-#       value: 3
-#   - notExists:
-#       path: spec.template.spec.containers[0].env[?(@.name=="RW_RESOURCE_GROUP")] 
+  - documentIndex: 2
+    equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: RW_RESOURCE_GROUP
+  - documentIndex: 2
+    equal:
+      path: spec.template.spec.containers[0].env[0].value
+      value: group-c
+- it: falls back to old behavior if resourceGroups is empty
+  set:
+    computeComponent:
+      resourceGroups: []
+      replicas: 3
+  asserts:
+  - documentIndex: 0
+    hasDocuments:
+      count: 1
+  - documentIndex: 0
+    equal:
+      path: spec.replicas
+      value: 3
+  - documentIndex: 0
+    notExists:
+      path: spec.template.spec.containers[0].env[?(@.name=="RW_RESOURCE_GROUP")] 

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -12,7 +12,7 @@ tests:
         - name: group-a
           replicas: 2
         - name: group-b
-          replicas: 1
+          replicas: 10
   asserts:
   - hasDocuments:
       count: 2
@@ -29,37 +29,49 @@ tests:
   - equal:
       path: spec.replicas
       value: 2
-      documentIndex: 0
+      documentSelector:
+        metadata:
+          name: RELEASE-NAME-risingwave-compute-group-a
   - equal:
       path: spec.replicas
-      value: 1
-      documentIndex: 1
+      value: 10
+      documentSelector:
+        metadata:
+          name: RELEASE-NAME-risingwave-compute-group-b
   - equal:
       path: spec.template.spec.containers[0].env[0].name
       value: RW_RESOURCE_GROUP
-      documentIndex: 0
+      documentSelector:
+        metadata:
+          name: RELEASE-NAME-risingwave-compute-group-a
   - equal:
       path: spec.template.spec.containers[0].env[0].value
       value: group-a
-      documentIndex: 0
+      documentSelector:
+        metadata:
+          name: RELEASE-NAME-risingwave-compute-group-a
   - equal:
       path: spec.template.spec.containers[0].env[0].name
       value: RW_RESOURCE_GROUP
-      documentIndex: 1
+      documentSelector:
+        metadata:
+          name: RELEASE-NAME-risingwave-compute-group-b
   - equal:
       path: spec.template.spec.containers[0].env[0].value
       value: group-b
-      documentIndex: 1
-- it: falls back to old behavior if resourceGroups is empty
-  set:
-    computeComponent:
-      resourceGroups: []
-      replicas: 3
-  asserts:
-  - hasDocuments:
-      count: 1
-  - equal:
-      path: spec.replicas
-      value: 3
-  - notExists:
-      path: spec.template.spec.containers[0].env[?(@.name=="RW_RESOURCE_GROUP")] 
+      documentSelector:
+        metadata:
+          name: RELEASE-NAME-risingwave-compute-group-b
+# - it: falls back to old behavior if resourceGroups is empty
+#   set:
+#     computeComponent:
+#       resourceGroups: []
+#       replicas: 3
+#   asserts:
+#   - hasDocuments:
+#       count: 1
+#   - equal:
+#       path: spec.replicas
+#       value: 3
+#   - notExists:
+#       path: spec.template.spec.containers[0].env[?(@.name=="RW_RESOURCE_GROUP")] 

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -85,4 +85,29 @@ tests:
       value: 3
   - documentIndex: 0
     notExists:
-      path: spec.template.spec.containers[0].env[?(@.name=="RW_RESOURCE_GROUP")] 
+      path: spec.template.spec.containers[?(@.name=="RW_RESOURCE_GROUP")] 
+- it: keeps all original containers when resourceGroups is empty
+  set:
+    computeComponent:
+      resourceGroups: []
+      replicas: 2
+      additionalContainers:
+        - name: sidecar
+          image: busybox
+          command: ["sleep", "3600"]
+    compactMode:
+      enabled: true
+  asserts:
+    - documentIndex: 0
+      lengthEqual:
+        path: spec.template.spec.containers
+        count: 3
+    - documentIndex: 0
+      exists:
+        path: spec.template.spec.containers[?(@.name=="compute")]
+    - documentIndex: 0
+      exists:
+        path: spec.template.spec.containers[?(@.name=="frontend")]
+    - documentIndex: 0
+      exists:
+        path: spec.template.spec.containers[?(@.name=="sidecar")]

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -1,0 +1,65 @@
+suite: Test compute resource groups
+templates:
+- compute-sts.yaml
+chart:
+  appVersion: 1.0.0
+  version: 0.0.1
+tests:
+- it: renders multiple StatefulSets for resource groups
+  set:
+    computeComponent:
+      resourceGroups:
+        - name: group-a
+          replicas: 2
+        - name: group-b
+          replicas: 1
+  asserts:
+  - hasDocuments:
+      count: 2
+  - containsDocument:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: RELEASE-NAME-risingwave-compute-group-a
+  - containsDocument:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: RELEASE-NAME-risingwave-compute-group-b
+  - equal:
+      path: spec.replicas
+      value: 2
+      documentIndex: 0
+  - equal:
+      path: spec.replicas
+      value: 1
+      documentIndex: 1
+  - equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: RW_RESOURCE_GROUP
+      documentIndex: 0
+  - equal:
+      path: spec.template.spec.containers[0].env[0].value
+      value: group-a
+      documentIndex: 0
+  - equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: RW_RESOURCE_GROUP
+      documentIndex: 1
+  - equal:
+      path: spec.template.spec.containers[0].env[0].value
+      value: group-b
+      documentIndex: 1
+- it: falls back to old behavior if resourceGroups is empty
+  set:
+    computeComponent:
+      resourceGroups: []
+      replicas: 3
+  asserts:
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: spec.replicas
+      value: 3
+  - notExists:
+      path: spec.template.spec.containers[0].env[?(@.name=="RW_RESOURCE_GROUP")] 

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -111,3 +111,30 @@ tests:
     - documentIndex: 0
       exists:
         path: spec.template.spec.containers[?(@.name=="sidecar")]
+- it: fails if resource group names are not unique
+  set:
+    computeComponent:
+      resourceGroups:
+        - name: group-a
+        - name: group-a
+  asserts:
+    - failedTemplate:
+        errorMessage: "Duplicate resource group name: 'group-a'"
+- it: fails if resource group name is 'default'
+  set:
+    computeComponent:
+      resourceGroups:
+        - name: default
+        - name: group-b
+  asserts:
+    - failedTemplate:
+        errorMessage: "Resource group name 'default' is not allowed."
+- it: fails if resource group name is empty
+  set:
+    computeComponent:
+      resourceGroups:
+        - name: ""
+        - name: group-b
+  asserts:
+    - failedTemplate:
+        errorMessage: "Each resource group must have a non-empty name."

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1035,7 +1035,9 @@ computeComponent:
   ## at least 'name' (required, must be unique) and 'replicas' (optional). Any other fields in computeComponent can be
   ## overridden per group; otherwise, they inherit from computeComponent. If set, a separate StatefulSet will be created
   ## for each group, and the environment variable RW_RESOURCE_GROUP will be set to the group's name in the container.
-  ##
+  ## Note that there will be always a default group which includes all configuration of computeComponent. Don't set
+  ## resource group name to "default" otherwise it will fail with error: "Duplicate resource group name".
+
   ## Example:
   ## resourceGroups:
   ##   - name: group-a

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -1031,6 +1031,19 @@ computeComponent:
   ##
   replicas: 1
 
+  ## @param computeComponent.resourceGroups List of resource groups for compute nodes. Each resource group is a map with
+  ## at least 'name' (required, must be unique) and 'replicas' (optional). Any other fields in computeComponent can be
+  ## overridden per group; otherwise, they inherit from computeComponent. If set, a separate StatefulSet will be created
+  ## for each group, and the environment variable RW_RESOURCE_GROUP will be set to the group's name in the container.
+  ##
+  ## Example:
+  ## resourceGroups:
+  ##   - name: group-a
+  ##     replicas: 2
+  ##   - name: group-b
+  ##     replicas: 1
+  resourceGroups: []
+
   ## @param computeComponent.autoscaling Compute Pod horizontal Pod Autoscalers
   ## Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics
   autoscaling:


### PR DESCRIPTION
## Summary
**Feature: Compute Resource Groups for RisingWave Helm Chart**
This PR introduces support for compute resource groups in the RisingWave Helm chart, enabling users to define multiple compute StatefulSets with distinct configurations within a single deployment.

**Key Changes**
Added a new array field (`computeComponent.resourceGroups`) under computeComponent in values.yaml.
Each entry is a map with at least a unique name and optional replicas and other compute fields.
Example:
```yaml
    computeComponent:
      resourceGroups:
        - name: group-a
          replicas: 2
        - name: group-b
          replicas: 5
```

**Template logic in compute-sts.yaml**

1. If resourceGroups is set and non-empty, the chart renders a separate StatefulSet for each group. Each StatefulSet inherits all fields from computeComponent unless overridden in the group.
2. The environment variable RW_RESOURCE_GROUP is injected into each container, set to the group’s name.
3. If resourceGroups is empty, the chart falls back to the original single StatefulSet behavior.


## Testing
1. Added a new Helm unittest (compute_resource_groups_test.yaml) to verify:

- Multiple StatefulSets are rendered for multiple groups, with correct names, replica counts, and environment variables.
- Fallback to the original behavior when resourceGroups is empty

2. Test helm chart deployment locally and verify its behaviour

Multiple compute nodes in different resource groups
<img width="1570" height="611" alt="Screenshot 2025-07-23 at 5 38 12 PM" src="https://github.com/user-attachments/assets/befab952-c4c8-4789-ba4e-d2d6dbbc864e" />

Create Table and MV in "large" resource group
<img width="573" height="685" alt="Screenshot 2025-07-23 at 5 35 29 PM" src="https://github.com/user-attachments/assets/2384d128-3598-4296-b737-0d47c71e5d53" />

