### PR TITLE
chore: use bitnamilegacy repository for bitnami images

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.34
+version: 0.2.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -25,6 +25,9 @@ tags:
 ## Ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 ##
 postgresql:
+  image:
+    repository: bitnami/postgresql
+
   auth:
     postgresPassword: "postgres"
     database: "risingwave"
@@ -46,6 +49,9 @@ postgresql:
 ## Ref: https://github.com/bitnami/charts/blob/main/bitnami/minio/values.yaml
 ##
 minio:
+  image:
+    repository: bitnami/minio
+
   defaultBuckets: risingwave
 
   auth:


### PR DESCRIPTION
Related https://github.com/bitnami/containers/issues/83267

In the future, we might migrate to the bitnami secure images for development.