### PR TITLE
docs: advise setting resource requests and limits to the same values

### DIFF
--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -246,6 +246,8 @@ standalone:
 
   ## @param standalone.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
+  ## performance and stability issues. A cpu:memory ratio of 1:4 is recommended.
   resources:
     limits: { }
     requests: { }
@@ -762,6 +764,8 @@ metaComponent:
 
   ## @param metaComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
+  ## performance and stability issues. A cpu:memory ratio of 1:4 is recommended.
   resources:
     limits: { }
     requests: { }
@@ -902,6 +906,8 @@ frontendComponent:
 
   ## @param frontendComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
+  ## performance and stability issues. A cpu:memory ratio of 1:4 is recommended.
   resources:
     limits: { }
     requests: { }
@@ -1067,6 +1073,8 @@ computeComponent:
 
   ## @param computeComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
+  ## performance and stability issues. A cpu:memory ratio of 1:4 is recommended.
   resources:
     limits: { }
     requests: { }
@@ -1209,6 +1217,8 @@ compactorComponent:
 
   ## @param compactorComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
+  ## performance and stability issues. A cpu:memory ratio of 1:4 is recommended.
   resources:
     limits: { }
     requests: { }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,6 +70,12 @@ For the two modes, the recommending resources are:
 
 ### Customize Pods of Different Components
 
+> [!IMPORTANT]
+>
+> When setting resource requests and limits, always set them to the **same values** to ensure guaranteed QoS class.
+> Using different values for requests and limits can cause performance and stability issues.
+> A cpu:memory ratio of **1:4** is recommended (e.g., 4 CPU / 16Gi memory).
+
 Most of the pod related values are under these sections:
 
 | Section            | Component  | Description                                    |
@@ -95,13 +101,19 @@ computeComponent:
       replicas: 2
       resources:
         requests:
-          cpu: 4
+          cpu: 8
+          memory: 32Gi
+        limits:
+          cpu: 8
           memory: 32Gi
     - name: cpu-intensive  
       replicas: 1
       resources:
         requests:
-          cpu: 8
+          cpu: 4
+          memory: 16Gi
+        limits:
+          cpu: 4
           memory: 16Gi
 ```
 


### PR DESCRIPTION
## Summary
- Add comments to all resource sections in `values.yaml` advising users to set requests and limits to the same values with a 1:4 cpu:memory ratio
- Add an `[!IMPORTANT]` callout in `CONFIGURATION.md` under "Customize Pods of Different Components"
- Fix resource group examples in `CONFIGURATION.md` to show matching requests/limits and correct 1:4 ratios

## Context
Mismatched resource requests and limits have caused performance and stability issues for on-prem users/customers. See https://risingwave-labs.slack.com/archives/C03DFGV6L2W/p1775720758587739

## Test plan
- [ ] Verify `helm template` still renders correctly
- [ ] Review rendered comments in `helm show values`

🤖 Generated with [Claude Code](https://claude.com/claude-code)