### PR TITLE
Support topology spread constraints

### DIFF
--- a/charts/risingwave/templates/compactor-deploy.yaml
+++ b/charts/risingwave/templates/compactor-deploy.yaml
@@ -82,6 +82,9 @@ spec:
       {{- if .Values.compactorComponent.affinity }}
       affinity: {{- toYaml .Values.compactorComponent.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.compactorComponent.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.compactorComponent.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.compactorComponent.schedulerName }}
       schedulerName: {{ .Values.compactorComponent.schedulerName }}
       {{- end }}

--- a/charts/risingwave/templates/compute-sts.yaml
+++ b/charts/risingwave/templates/compute-sts.yaml
@@ -153,6 +153,9 @@ spec:
       {{- if $comp.affinity }}
       affinity: {{- toYaml $comp.affinity | nindent 8 }}
       {{- end }}
+      {{- if $comp.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml $comp.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if $comp.schedulerName }}
       schedulerName: {{ $comp.schedulerName }}
       {{- end }}

--- a/charts/risingwave/templates/frontend-deploy.yaml
+++ b/charts/risingwave/templates/frontend-deploy.yaml
@@ -88,6 +88,9 @@ spec:
       {{- if .Values.frontendComponent.affinity }}
       affinity: {{- toYaml .Values.frontendComponent.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.frontendComponent.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.frontendComponent.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.frontendComponent.schedulerName }}
       schedulerName: {{ .Values.frontendComponent.schedulerName }}
       {{- end }}

--- a/charts/risingwave/templates/iceberg-compactor-deploy.yaml
+++ b/charts/risingwave/templates/iceberg-compactor-deploy.yaml
@@ -82,6 +82,9 @@ spec:
       {{- if .Values.icebergCompactorComponent.affinity }}
       affinity: {{- toYaml .Values.icebergCompactorComponent.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.icebergCompactorComponent.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.icebergCompactorComponent.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.icebergCompactorComponent.schedulerName }}
       schedulerName: {{ .Values.icebergCompactorComponent.schedulerName }}
       {{- end }}

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -95,6 +95,9 @@ spec:
       {{- if .Values.metaComponent.affinity }}
       affinity: {{- toYaml .Values.metaComponent.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.metaComponent.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.metaComponent.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.metaComponent.schedulerName }}
       schedulerName: {{ .Values.metaComponent.schedulerName }}
       {{- end }}

--- a/charts/risingwave/tests/compute_resource_groups_test.yaml
+++ b/charts/risingwave/tests/compute_resource_groups_test.yaml
@@ -101,6 +101,60 @@ tests:
     - documentIndex: 0
       exists:
         path: spec.template.spec.containers[?(@.name=="sidecar")]
+- it: resource groups can override topology spread constraints
+  set:
+    computeComponent:
+      replicas: 3
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            group: default
+      resourceGroups:
+        - name: group-a
+          replicas: 2
+          topologySpreadConstraints:
+          - maxSkew: 2
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                group: a
+        - name: group-b
+          replicas: 1
+  asserts:
+    - documentIndex: 0
+      equal:
+        path: spec.template.spec.topologySpreadConstraints
+        value:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              group: default
+    - documentIndex: 1
+      equal:
+        path: spec.template.spec.topologySpreadConstraints
+        value:
+        - maxSkew: 2
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              group: a
+    - documentIndex: 2
+      equal:
+        path: spec.template.spec.topologySpreadConstraints
+        value:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              group: default
 - it: fails if resource group names are not unique
   set:
     computeComponent:

--- a/charts/risingwave/tests/workloads_common_test.yaml
+++ b/charts/risingwave/tests/workloads_common_test.yaml
@@ -70,3 +70,67 @@ tests:
   asserts:
   - isNotNullOrEmpty:
       path: spec.template.metadata.annotations["risingwave.risingwavelabs.com/config-hash"]
+- it: workloads should reflect topology spread constraints
+  set:
+    metaComponent:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: foo
+        matchLabelKeys:
+        - pod-template-hash
+    computeComponent:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: foo
+        matchLabelKeys:
+        - pod-template-hash
+    frontendComponent:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: foo
+        matchLabelKeys:
+        - pod-template-hash
+    compactorComponent:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: foo
+        matchLabelKeys:
+        - pod-template-hash
+    icebergCompactorComponent:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: foo
+        matchLabelKeys:
+        - pod-template-hash
+  asserts:
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints
+      value:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: foo
+        matchLabelKeys:
+        - pod-template-hash

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -801,6 +801,11 @@ metaComponent:
   ##
   affinity: { }
 
+  ## @param metaComponent.topologySpreadConstraints Topology spread constraints for pod assignment.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  ##
+  topologySpreadConstraints: [ ]
+
   ## @param metaComponent.terminationGracePeriodSeconds Termination grace period in seconds.
   ## Defaults to 1 seconds.
   ##
@@ -942,6 +947,11 @@ frontendComponent:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
   affinity: { }
+
+  ## @param frontendComponent.topologySpreadConstraints Topology spread constraints for pod assignment.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  ##
+  topologySpreadConstraints: [ ]
 
   ## @param frontendComponent.terminationGracePeriodSeconds Termination grace period in seconds.
   ## Defaults to 10 seconds.
@@ -1110,6 +1120,11 @@ computeComponent:
   ##
   affinity: { }
 
+  ## @param computeComponent.topologySpreadConstraints Topology spread constraints for pod assignment.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  ##
+  topologySpreadConstraints: [ ]
+
   ## @param computeComponent.terminationGracePeriodSeconds Termination grace period in seconds.
   ## Defaults to 1 seconds.
   ##
@@ -1253,6 +1268,11 @@ compactorComponent:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
   affinity: { }
+
+  ## @param compactorComponent.topologySpreadConstraints Topology spread constraints for pod assignment.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  ##
+  topologySpreadConstraints: [ ]
 
   ## @param compactorComponent.terminationGracePeriodSeconds Termination grace period in seconds.
   ## Defaults to 1 seconds.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,7 +87,20 @@ Most of the pod related values are under these sections:
 | compactorComponent | Compactor  | Customizing the Deployment for compactor pods  |
 
 Almost all possible fields on the raw workloads are exposed,
-including `replicas`, `resources`, `nodeSelector`, `affinity`, `tolerations` and others.
+including `replicas`, `resources`, `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints` and others.
+
+For distributed mode components, topology spread constraints can be configured per component:
+
+```yaml
+computeComponent:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          risingwave.risingwavelabs.com/component: compute
+```
 
 #### Resource Groups for Compute Nodes
 
@@ -354,6 +367,11 @@ manager:
   affinity: { }
 
   tolerations: [ ]
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
 
   resources:
     limits:


### PR DESCRIPTION
## Summary
- Add topologySpreadConstraints values for distributed RisingWave workloads
- Render the constraints into meta, compute, frontend, compactor, and Iceberg compactor pod specs
- Document the new scheduling knob and add Helm unittest coverage, including compute resource group override behavior

Closes #226

## Tests
- helm dependency update charts/risingwave
- helm lint --strict --set tags.bundle=true charts/risingwave
- helm unittest --strict -f tests/workloads_common_test.yaml charts/risingwave
- helm unittest --strict -f tests/compute_resource_groups_test.yaml charts/risingwave
- helm template topology-test charts/risingwave --show-only templates/meta-sts.yaml --set tags.bundle=true --set 'metaComponent.topologySpreadConstraints[0].maxSkew=1' --set 'metaComponent.topologySpreadConstraints[0].topologyKey=kubernetes.io/hostname' --set 'metaComponent.topologySpreadConstraints[0].whenUnsatisfiable=DoNotSchedule'

Note: full helm unittest --strict -f 'tests/**/*_test.yaml' charts/risingwave currently fails in existing configmap_test.yaml string block isSubset assertions unrelated to this change; the new/changed suites pass.