### PR TITLE
Support HPA for non-compute components

### DIFF
--- a/charts/risingwave/templates/autoscaler.yaml
+++ b/charts/risingwave/templates/autoscaler.yaml
@@ -3,31 +3,51 @@
   SPDX-License-Identifier: APACHE-2.0
   */}}
 
-{{- if .Values.computeComponent.autoscaling.enabled -}}
+{{- $hpas := list }}
+{{- if .Values.computeComponent.autoscaling.enabled }}
+  {{- $hpas = append $hpas (dict "component" "compute" "name" (include "risingwave.computeComponentName" .) "kind" "StatefulSet" "replicas" .Values.computeComponent.replicas "autoscaling" .Values.computeComponent.autoscaling) }}
+{{- end }}
+{{- if and (not .Values.standalone.enabled) .Values.metaComponent.autoscaling.enabled }}
+  {{- $hpas = append $hpas (dict "component" "meta" "name" (include "risingwave.metaComponentName" .) "kind" "StatefulSet" "replicas" .Values.metaComponent.replicas "autoscaling" .Values.metaComponent.autoscaling) }}
+{{- end }}
+{{- if and (not .Values.standalone.enabled) (not .Values.compactMode.enabled) .Values.frontendComponent.autoscaling.enabled }}
+  {{- $hpas = append $hpas (dict "component" "frontend" "name" (include "risingwave.frontendComponentName" .) "kind" "Deployment" "replicas" .Values.frontendComponent.replicas "autoscaling" .Values.frontendComponent.autoscaling) }}
+{{- end }}
+{{- if and (not .Values.standalone.enabled) .Values.compactorComponent.autoscaling.enabled }}
+  {{- $hpas = append $hpas (dict "component" "compactor" "name" (include "risingwave.compactorComponentName" .) "kind" "Deployment" "replicas" .Values.compactorComponent.replicas "autoscaling" .Values.compactorComponent.autoscaling) }}
+{{- end }}
+{{- if and (not .Values.standalone.enabled) .Values.icebergCompactorComponent.enabled .Values.icebergCompactorComponent.autoscaling.enabled }}
+  {{- $hpas = append $hpas (dict "component" "iceberg-compactor" "name" (include "risingwave.icebergCompactorComponentName" .) "kind" "Deployment" "replicas" .Values.icebergCompactorComponent.replicas "autoscaling" .Values.icebergCompactorComponent.autoscaling) }}
+{{- end }}
+
+{{- range $index, $hpa := $hpas }}
+{{- if gt $index 0 }}
+---
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "risingwave.computeComponentName" . }}-autoscaler
-  namespace: {{ .Release.Namespace }}
+  name: {{ $hpa.name }}-autoscaler
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "risingwave.labels" . | nindent 4 }}
-    risingwave.risingwavelabs.com/component: compute
-  {{- $annotations := (include "risingwave.annotations" . ) | trim }}
+    {{- include "risingwave.labels" $ | nindent 4 }}
+    risingwave.risingwavelabs.com/component: {{ $hpa.component }}
+  {{- $annotations := (include "risingwave.annotations" $ ) | trim }}
   {{- if $annotations }}
   annotations:
     {{ nindent 4 $annotations }}
   {{- end }}
 spec:
-  maxReplicas: {{ .Values.computeComponent.autoscaling.maxReplicas }}
-  minReplicas: {{ .Values.computeComponent.replicas }}
+  maxReplicas: {{ $hpa.autoscaling.maxReplicas }}
+  minReplicas: {{ $hpa.replicas }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: StatefulSet
-    name: {{ include "risingwave.computeComponentName" . }}
-  {{- if .Values.computeComponent.autoscaling.metrics }}
-  metrics: {{ toYaml .Values.computeComponent.autoscaling.metrics | nindent 4}}
+    kind: {{ $hpa.kind }}
+    name: {{ $hpa.name }}
+  {{- if $hpa.autoscaling.metrics }}
+  metrics: {{ toYaml $hpa.autoscaling.metrics | nindent 4}}
   {{- end }}
-  {{- if .Values.computeComponent.autoscaling.behavior }}
-  behavior: {{ toYaml .Values.computeComponent.autoscaling.behavior | nindent 4 }}
+  {{- if $hpa.autoscaling.behavior }}
+  behavior: {{ toYaml $hpa.autoscaling.behavior | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/risingwave/templates/compactor-deploy.yaml
+++ b/charts/risingwave/templates/compactor-deploy.yaml
@@ -17,7 +17,9 @@ metadata:
     {{ nindent 4 $annotations }}
   {{- end }}
 spec:
+  {{- if not .Values.compactorComponent.autoscaling.enabled }}
   replicas: {{ .Values.compactorComponent.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "risingwave.selectorLabels" . | nindent 6 }}

--- a/charts/risingwave/templates/frontend-deploy.yaml
+++ b/charts/risingwave/templates/frontend-deploy.yaml
@@ -18,7 +18,9 @@ metadata:
     {{ nindent 4 $annotations }}
   {{- end }}
 spec:
+  {{- if not .Values.frontendComponent.autoscaling.enabled }}
   replicas: {{ .Values.frontendComponent.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "risingwave.selectorLabels" . | nindent 6 }}

--- a/charts/risingwave/templates/iceberg-compactor-deploy.yaml
+++ b/charts/risingwave/templates/iceberg-compactor-deploy.yaml
@@ -17,7 +17,9 @@ metadata:
     {{ nindent 4 $annotations }}
   {{- end }}
 spec:
+  {{- if not .Values.icebergCompactorComponent.autoscaling.enabled }}
   replicas: {{ .Values.icebergCompactorComponent.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "risingwave.selectorLabels" . | nindent 6 }}

--- a/charts/risingwave/templates/meta-sts.yaml
+++ b/charts/risingwave/templates/meta-sts.yaml
@@ -17,7 +17,9 @@ metadata:
     {{ nindent 4 $annotations }}
   {{- end }}
 spec:
+  {{- if not .Values.metaComponent.autoscaling.enabled }}
   replicas: {{ .Values.metaComponent.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "risingwave.selectorLabels" . | nindent 6 }}

--- a/charts/risingwave/tests/autoscaler_test.yaml
+++ b/charts/risingwave/tests/autoscaler_test.yaml
@@ -5,15 +5,12 @@ chart:
   appVersion: 1.0.0
   version: 0.0.1
 tests:
-  - it: HorizontalPodAutoscaler should not exist when enabled is false
-    set:
-      computeComponent:
-        autoscaling:
-          enabled: false
+  - it: HorizontalPodAutoscaler should not exist when autoscaling is disabled
     asserts:
       - hasDocuments:
           count: 0
-  - it: HorizontalPodAutoscaler should exist when enabled is true
+
+  - it: HorizontalPodAutoscaler should exist for compute when enabled
     set:
       computeComponent:
         autoscaling:
@@ -21,9 +18,129 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-compute-autoscaler
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: StatefulSet
+            name: RELEASE-NAME-risingwave-compute
+
+  - it: HorizontalPodAutoscaler should exist for meta when enabled
+    set:
+      metaComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-meta-autoscaler
+      - isSubset:
+          path: metadata.labels
+          content:
+            risingwave.risingwavelabs.com/component: meta
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: StatefulSet
+            name: RELEASE-NAME-risingwave-meta
+
+  - it: HorizontalPodAutoscaler should exist for frontend when enabled
+    set:
+      frontendComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-frontend-autoscaler
+      - isSubset:
+          path: metadata.labels
+          content:
+            risingwave.risingwavelabs.com/component: frontend
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: RELEASE-NAME-risingwave-frontend
+
+  - it: HorizontalPodAutoscaler should not exist for frontend in compact mode
+    set:
+      compactMode:
+        enabled: true
+      frontendComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HorizontalPodAutoscaler should exist for compactor when enabled
+    set:
+      compactorComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-compactor-autoscaler
+      - isSubset:
+          path: metadata.labels
+          content:
+            risingwave.risingwavelabs.com/component: compactor
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: RELEASE-NAME-risingwave-compactor
+
+  - it: HorizontalPodAutoscaler should exist for iceberg compactor when enabled
+    set:
+      icebergCompactorComponent:
+        enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-iceberg-compactor-autoscaler
+      - isSubset:
+          path: metadata.labels
+          content:
+            risingwave.risingwavelabs.com/component: iceberg-compactor
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: RELEASE-NAME-risingwave-iceberg-compactor
+
+  - it: HorizontalPodAutoscaler should not exist for iceberg compactor when component is disabled
+    set:
+      icebergCompactorComponent:
+        enabled: false
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: HorizontalPodAutoscaler should reflect common labels and annotations
     set:
-      computeComponent:
+      metaComponent:
         autoscaling:
           enabled: true
       commonLabels:
@@ -37,29 +154,32 @@ tests:
           path: metadata.labels
           content:
             LABEL: LABEL_V
+            risingwave.risingwavelabs.com/component: meta
       - exists:
           path: metadata.annotations
       - isSubset:
           path: metadata.annotations
           content:
             ANNOTATION: ANNOTATION_V
-  - it: HorizontalPodAutoscaler should reflect computeComponent replicas and autoscaling maxReplicas
+
+  - it: HorizontalPodAutoscaler should reflect replicas and autoscaling maxReplicas
     set:
-      computeComponent:
+      compactorComponent:
+        replicas: 2
         autoscaling:
           enabled: true
-          maxReplicas : 5
-        replicas: 1
+          maxReplicas: 5
     asserts:
       - equal:
           path: spec.maxReplicas
           value: 5
       - equal:
           path: spec.minReplicas
-          value: 1
-  - it: HorizontalPodAutoscaler should reflect computeComponent autoscaling metrics and behavior
+          value: 2
+
+  - it: HorizontalPodAutoscaler should reflect autoscaling metrics and behavior
     set:
-      computeComponent:
+      frontendComponent:
         autoscaling:
           enabled: true
           metrics:
@@ -67,8 +187,8 @@ tests:
               resource:
                 name: memory
                 target:
-                type: Utilization
-                averageUtilization: 30
+                  type: Utilization
+                  averageUtilization: 30
           behavior:
             scaleDown:
               stabilizationWindowSeconds: 300
@@ -91,8 +211,8 @@ tests:
             resource:
               name: memory
               target:
-              type: Utilization
-              averageUtilization: 30
+                type: Utilization
+                averageUtilization: 30
       - equal:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds
           value: 300
@@ -114,3 +234,59 @@ tests:
       - equal:
           path: spec.behavior.scaleUp.selectPolicy
           value: Max
+
+  - it: HorizontalPodAutoscalers should render for all non-compute distributed components
+    set:
+      metaComponent:
+        autoscaling:
+          enabled: true
+      frontendComponent:
+        autoscaling:
+          enabled: true
+      compactorComponent:
+        autoscaling:
+          enabled: true
+      icebergCompactorComponent:
+        enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-meta-autoscaler
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-frontend-autoscaler
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-compactor-autoscaler
+      - documentIndex: 3
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-risingwave-iceberg-compactor-autoscaler
+
+  - it: HorizontalPodAutoscaler should not exist for non-compute components in standalone mode
+    set:
+      standalone:
+        enabled: true
+      metaComponent:
+        autoscaling:
+          enabled: true
+      frontendComponent:
+        autoscaling:
+          enabled: true
+      compactorComponent:
+        autoscaling:
+          enabled: true
+      icebergCompactorComponent:
+        enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/risingwave/tests/autoscaling_workloads_test.yaml
+++ b/charts/risingwave/tests/autoscaling_workloads_test.yaml
@@ -1,0 +1,88 @@
+suite: Test workload replicas with autoscaling
+chart:
+  appVersion: 1.0.0
+  version: 0.0.1
+set:
+  tags:
+    minio: true
+    postgresql: true
+tests:
+  - it: meta statefulset should include replicas by default
+    templates:
+      - templates/meta-sts.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: meta statefulset should omit replicas when autoscaling is enabled
+    templates:
+      - templates/meta-sts.yaml
+    set:
+      metaComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: frontend deployment should include replicas by default
+    templates:
+      - templates/frontend-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: frontend deployment should omit replicas when autoscaling is enabled
+    templates:
+      - templates/frontend-deploy.yaml
+    set:
+      frontendComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: compactor deployment should include replicas by default
+    templates:
+      - templates/compactor-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: compactor deployment should omit replicas when autoscaling is enabled
+    templates:
+      - templates/compactor-deploy.yaml
+    set:
+      compactorComponent:
+        autoscaling:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: iceberg compactor deployment should include replicas by default
+    templates:
+      - templates/iceberg-compactor-deploy.yaml
+    set:
+      icebergCompactorComponent:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: iceberg compactor deployment should omit replicas when autoscaling is enabled
+    templates:
+      - templates/iceberg-compactor-deploy.yaml
+    set:
+      icebergCompactorComponent:
+        enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -762,6 +762,14 @@ metaComponent:
   ##
   replicas: 1
 
+  ## @param metaComponent.autoscaling Meta Pod horizontal Pod Autoscalers
+  ## Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics
+  autoscaling:
+    enabled: false
+    maxReplicas: 5
+    metrics: null
+    behavior: null
+
   ## @param metaComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
@@ -903,6 +911,14 @@ frontendComponent:
   ## @param frontendComponent.replicas Number of replicas.
   ##
   replicas: 1
+
+  ## @param frontendComponent.autoscaling Frontend Pod horizontal Pod Autoscalers
+  ## Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics
+  autoscaling:
+    enabled: false
+    maxReplicas: 5
+    metrics: null
+    behavior: null
 
   ## @param frontendComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -1215,6 +1231,14 @@ compactorComponent:
   ##
   replicas: 1
 
+  ## @param compactorComponent.autoscaling Compactor Pod horizontal Pod Autoscalers
+  ## Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics
+  autoscaling:
+    enabled: false
+    maxReplicas: 5
+    metrics: null
+    behavior: null
+
   ## @param compactorComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
@@ -1317,6 +1341,14 @@ icebergCompactorComponent:
   ## @param icebergCompactorComponent.replicas Number of replicas.
   ##
   replicas: 1
+
+  ## @param icebergCompactorComponent.autoscaling Iceberg compactor Pod horizontal Pod Autoscalers
+  ## Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics
+  autoscaling:
+    enabled: false
+    maxReplicas: 5
+    metrics: null
+    behavior: null
 
   ## All configurations are the same as compactorComponent.
   ## For brevity, they are not repeated here.


### PR DESCRIPTION
## Summary
- Closes #227
- Add per-component HPA values for meta, frontend, compactor, and Iceberg compactor
- Render HPAs only when the matching distributed workload exists
- Omit workload spec.replicas when that workload is controlled by an HPA

## Tests
- helm dependency build charts/risingwave
- helm lint --strict --set tags.bundle=true charts/risingwave
- helm unittest --strict -f tests/autoscaler_test.yaml -f tests/autoscaling_workloads_test.yaml charts/risingwave
- helm template rw charts/risingwave --set tags.minio=true --set tags.postgresql=true --set metaComponent.autoscaling.enabled=true --set frontendComponent.autoscaling.enabled=true --set compactorComponent.autoscaling.enabled=true --set icebergCompactorComponent.enabled=true --set icebergCompactorComponent.autoscaling.enabled=true

Note: full helm unittest currently has unrelated existing failures in charts/risingwave/tests/configmap_test.yaml.