### PR TITLE
Support PDB for RisingWave components

### DIFF
--- a/charts/risingwave/templates/pdb.yaml
+++ b/charts/risingwave/templates/pdb.yaml
@@ -1,0 +1,135 @@
+{{/*
+Copyright RisingWave Labs.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- define "risingwave.podDisruptionBudget" -}}
+{{- $root := .root -}}
+{{- $pdb := .podDisruptionBudget | default dict -}}
+{{- if $pdb.enabled -}}
+{{- $minAvailable := get $pdb "minAvailable" -}}
+{{- $maxUnavailable := get $pdb "maxUnavailable" -}}
+{{- $hasMinAvailable := ne (toString $minAvailable) "" -}}
+{{- $hasMaxUnavailable := ne (toString $maxUnavailable) "" -}}
+{{- if eq $hasMinAvailable $hasMaxUnavailable -}}
+{{- fail (printf "%s.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable" .valuesPath) -}}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "%s-pdb" .name }}
+  labels:
+    {{- include "risingwave.labels" $root | nindent 4 }}
+    risingwave.risingwavelabs.com/component: {{ .component }}
+    {{- with .resourceGroup }}
+    risingwave.risingwavelabs.com/resource-group: {{ . }}
+    {{- end }}
+  {{- $annotations := (include "risingwave.annotations" $root) | trim }}
+  {{- if $annotations }}
+  annotations:
+    {{ nindent 4 $annotations }}
+  {{- end }}
+spec:
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ $minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ $maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "risingwave.selectorLabels" $root | nindent 6 }}
+      risingwave.risingwavelabs.com/component: {{ .component }}
+      {{- with .resourceGroup }}
+      risingwave.risingwavelabs.com/resource-group: {{ . }}
+      {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{- if not .Values.standalone.enabled -}}
+{{- include "risingwave.podDisruptionBudget" (dict
+  "root" .
+  "name" (include "risingwave.metaComponentName" .)
+  "component" "meta"
+  "podDisruptionBudget" .Values.metaComponent.podDisruptionBudget
+  "valuesPath" "metaComponent"
+) }}
+
+{{- if not .Values.compactMode.enabled }}
+{{- include "risingwave.podDisruptionBudget" (dict
+  "root" .
+  "name" (include "risingwave.frontendComponentName" .)
+  "component" "frontend"
+  "podDisruptionBudget" .Values.frontendComponent.podDisruptionBudget
+  "valuesPath" "frontendComponent"
+) }}
+{{- end }}
+
+{{- $resourceGroups := .Values.computeComponent.resourceGroups | default list }}
+{{- $hasGroups := gt (len $resourceGroups) 0 }}
+{{- $defaultGroup := dict "name" "default" }}
+{{- $allGroups := list $defaultGroup }}
+{{- if $hasGroups }}
+  {{- $nameMap := dict }}
+  {{- $_ := set $nameMap "default" true }}
+  {{- range $group := $resourceGroups }}
+    {{- $name := $group.name | default "" }}
+    {{- if eq $name "" }}
+      {{- fail "Each resource group must have a non-empty name." }}
+    {{- end }}
+    {{- if hasKey $nameMap $name }}
+      {{- fail (printf "Duplicate resource group name: '%s'" $name) }}
+    {{- end }}
+    {{- $_ := set $nameMap $name true }}
+    {{- $allGroups = append $allGroups $group }}
+  {{- end }}
+{{- end }}
+{{- range $group := $allGroups }}
+  {{- $ctx := deepCopy $ }}
+  {{- $comp := dict }}
+  {{- range $k, $v := $.Values.computeComponent }}
+    {{- $_ := set $comp $k $v }}
+  {{- end }}
+  {{- if ne $group.name "default" }}
+    {{- range $k, $v := $group }}
+      {{- $_ := set $comp $k $v }}
+    {{- end }}
+  {{- end }}
+  {{- $_ := set $ctx.Values "computeComponent" $comp }}
+  {{- $_ := set $ctx.Values.computeComponent "resourceGroupName" $group.name }}
+  {{- $name := include "risingwave.computeComponentName" $ctx }}
+  {{- if ne $group.name "default" }}
+    {{- $name = printf "%s-%s" $name $group.name }}
+  {{- end }}
+  {{- $valuesPath := "computeComponent" }}
+  {{- if ne $group.name "default" }}
+    {{- $valuesPath = printf "computeComponent.resourceGroups[%s]" $group.name }}
+  {{- end }}
+{{- include "risingwave.podDisruptionBudget" (dict
+  "root" $ctx
+  "name" $name
+  "component" "compute"
+  "resourceGroup" (ternary "" $group.name (eq $group.name "default"))
+  "podDisruptionBudget" $comp.podDisruptionBudget
+  "valuesPath" $valuesPath
+) }}
+{{- end }}
+
+{{- include "risingwave.podDisruptionBudget" (dict
+  "root" .
+  "name" (include "risingwave.compactorComponentName" .)
+  "component" "compactor"
+  "podDisruptionBudget" .Values.compactorComponent.podDisruptionBudget
+  "valuesPath" "compactorComponent"
+) }}
+
+{{- if .Values.icebergCompactorComponent.enabled }}
+{{- include "risingwave.podDisruptionBudget" (dict
+  "root" .
+  "name" (include "risingwave.icebergCompactorComponentName" .)
+  "component" "iceberg-compactor"
+  "podDisruptionBudget" .Values.icebergCompactorComponent.podDisruptionBudget
+  "valuesPath" "icebergCompactorComponent"
+) }}
+{{- end }}
+{{- end -}}

--- a/charts/risingwave/tests/pdb_test.yaml
+++ b/charts/risingwave/tests/pdb_test.yaml
@@ -1,0 +1,413 @@
+suite: Test pod disruption budgets
+templates:
+- templates/pdb.yaml
+chart:
+  appVersion: 1.0.0
+  version: 0.0.1
+tests:
+- it: pod disruption budgets should not render by default
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: pod disruption budgets should render for distributed components
+  set:
+    commonLabels:
+      LABEL: LABEL_V
+    commonAnnotations:
+      ANNOTATION: ANNOTATION_V
+    metaComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    frontendComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    computeComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    compactorComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    icebergCompactorComponent:
+      enabled: true
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+  asserts:
+  - hasDocuments:
+      count: 5
+  - documentIndex: 0
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-meta-pdb
+  - documentIndex: 0
+    equal:
+      path: spec.maxUnavailable
+      value: 1
+  - documentIndex: 0
+    isSubset:
+      path: metadata.labels
+      content:
+        helm.sh/chart: risingwave-0.0.1
+        app.kubernetes.io/name: risingwave
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/version: 1.0.0
+        app.kubernetes.io/instance: RELEASE-NAME
+        risingwave.risingwavelabs.com/component: meta
+        LABEL: LABEL_V
+  - documentIndex: 0
+    isSubset:
+      path: metadata.annotations
+      content:
+        ANNOTATION: ANNOTATION_V
+  - documentIndex: 0
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        app.kubernetes.io/name: risingwave
+        app.kubernetes.io/instance: RELEASE-NAME
+        risingwave.risingwavelabs.com/component: meta
+  - documentIndex: 1
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-frontend-pdb
+  - documentIndex: 1
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: frontend
+  - documentIndex: 2
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-pdb
+  - documentIndex: 2
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: compute
+  - documentIndex: 3
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compactor-pdb
+  - documentIndex: 3
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: compactor
+  - documentIndex: 4
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-iceberg-compactor-pdb
+  - documentIndex: 4
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: iceberg-compactor
+- it: pod disruption budget should support minAvailable
+  set:
+    metaComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+  asserts:
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: spec.minAvailable
+      value: 1
+  - notExists:
+      path: spec.maxUnavailable
+- it: non-meta pod disruption budgets should support minAvailable
+  set:
+    frontendComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    computeComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    compactorComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 50%
+    icebergCompactorComponent:
+      enabled: true
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+  asserts:
+  - hasDocuments:
+      count: 4
+  - documentIndex: 0
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-frontend-pdb
+  - documentIndex: 0
+    equal:
+      path: spec.minAvailable
+      value: 1
+  - documentIndex: 0
+    notExists:
+      path: spec.maxUnavailable
+  - documentIndex: 1
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-pdb
+  - documentIndex: 1
+    equal:
+      path: spec.minAvailable
+      value: 2
+  - documentIndex: 1
+    notExists:
+      path: spec.maxUnavailable
+  - documentIndex: 2
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compactor-pdb
+  - documentIndex: 2
+    equal:
+      path: spec.minAvailable
+      value: 50%
+  - documentIndex: 2
+    notExists:
+      path: spec.maxUnavailable
+  - documentIndex: 3
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-iceberg-compactor-pdb
+  - documentIndex: 3
+    equal:
+      path: spec.minAvailable
+      value: 1
+  - documentIndex: 3
+    notExists:
+      path: spec.maxUnavailable
+- it: frontend pod disruption budget should not render in compact mode
+  set:
+    compactMode:
+      enabled: true
+    frontendComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: iceberg compactor pod disruption budget should not render when iceberg compactor is disabled
+  set:
+    icebergCompactorComponent:
+      enabled: false
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: compute pod disruption budgets should render for resource groups
+  set:
+    computeComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+      resourceGroups:
+      - name: group-a
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+      - name: group-b
+  asserts:
+  - hasDocuments:
+      count: 3
+  - documentIndex: 0
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-pdb
+  - documentIndex: 0
+    equal:
+      path: spec.maxUnavailable
+      value: 1
+  - documentIndex: 0
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: compute
+  - documentIndex: 1
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-group-a-pdb
+  - documentIndex: 1
+    equal:
+      path: spec.minAvailable
+      value: 1
+  - documentIndex: 1
+    isSubset:
+      path: metadata.labels
+      content:
+        risingwave.risingwavelabs.com/component: compute
+        risingwave.risingwavelabs.com/resource-group: group-a
+  - documentIndex: 1
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: compute
+        risingwave.risingwavelabs.com/resource-group: group-a
+  - documentIndex: 2
+    equal:
+      path: metadata.name
+      value: RELEASE-NAME-risingwave-compute-group-b-pdb
+  - documentIndex: 2
+    equal:
+      path: spec.maxUnavailable
+      value: 1
+  - documentIndex: 2
+    isSubset:
+      path: spec.selector.matchLabels
+      content:
+        risingwave.risingwavelabs.com/component: compute
+        risingwave.risingwavelabs.com/resource-group: group-b
+- it: pod disruption budget should fail when no budget is set
+  set:
+    metaComponent:
+      podDisruptionBudget:
+        enabled: true
+  asserts:
+  - failedTemplate:
+      errorMessage: "metaComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: frontend pod disruption budget should fail when no budget is set
+  set:
+    frontendComponent:
+      podDisruptionBudget:
+        enabled: true
+  asserts:
+  - failedTemplate:
+      errorMessage: "frontendComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: compute pod disruption budget should fail when no budget is set
+  set:
+    computeComponent:
+      podDisruptionBudget:
+        enabled: true
+  asserts:
+  - failedTemplate:
+      errorMessage: "computeComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: compactor pod disruption budget should fail when no budget is set
+  set:
+    compactorComponent:
+      podDisruptionBudget:
+        enabled: true
+  asserts:
+  - failedTemplate:
+      errorMessage: "compactorComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: iceberg compactor pod disruption budget should fail when no budget is set
+  set:
+    icebergCompactorComponent:
+      enabled: true
+      podDisruptionBudget:
+        enabled: true
+  asserts:
+  - failedTemplate:
+      errorMessage: "icebergCompactorComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: compute resource group pod disruption budget should fail when no budget is set
+  set:
+    computeComponent:
+      resourceGroups:
+      - name: group-a
+        podDisruptionBudget:
+          enabled: true
+  asserts:
+  - failedTemplate:
+      errorMessage: "computeComponent.resourceGroups[group-a].podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: pod disruption budget should fail when both budgets are set
+  set:
+    metaComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+  asserts:
+  - failedTemplate:
+      errorMessage: "metaComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: frontend pod disruption budget should fail when both budgets are set
+  set:
+    frontendComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+  asserts:
+  - failedTemplate:
+      errorMessage: "frontendComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: compute pod disruption budget should fail when both budgets are set
+  set:
+    computeComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+  asserts:
+  - failedTemplate:
+      errorMessage: "computeComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: compactor pod disruption budget should fail when both budgets are set
+  set:
+    compactorComponent:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+  asserts:
+  - failedTemplate:
+      errorMessage: "compactorComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: iceberg compactor pod disruption budget should fail when both budgets are set
+  set:
+    icebergCompactorComponent:
+      enabled: true
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+  asserts:
+  - failedTemplate:
+      errorMessage: "icebergCompactorComponent.podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: compute resource group pod disruption budget should fail when both budgets are set
+  set:
+    computeComponent:
+      resourceGroups:
+      - name: group-a
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+          maxUnavailable: 1
+  asserts:
+  - failedTemplate:
+      errorMessage: "computeComponent.resourceGroups[group-a].podDisruptionBudget requires exactly one of minAvailable or maxUnavailable"
+- it: pod disruption budgets should not render in standalone mode
+  set:
+    standalone:
+      enabled: true
+    metaComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    frontendComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    computeComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    compactorComponent:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    icebergCompactorComponent:
+      enabled: true
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/risingwave/values.yaml
+++ b/charts/risingwave/values.yaml
@@ -762,6 +762,16 @@ metaComponent:
   ##
   replicas: 1
 
+  ## @param metaComponent.podDisruptionBudget.enabled Enable PodDisruptionBudget for meta pods.
+  ## @param metaComponent.podDisruptionBudget.minAvailable Minimum number or percentage of pods that must remain available.
+  ## @param metaComponent.podDisruptionBudget.maxUnavailable Maximum number or percentage of pods that can be unavailable.
+  ## Set exactly one of minAvailable or maxUnavailable when enabled.
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: ""
+    maxUnavailable: ""
+
   ## @param metaComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
@@ -903,6 +913,16 @@ frontendComponent:
   ## @param frontendComponent.replicas Number of replicas.
   ##
   replicas: 1
+
+  ## @param frontendComponent.podDisruptionBudget.enabled Enable PodDisruptionBudget for frontend pods.
+  ## @param frontendComponent.podDisruptionBudget.minAvailable Minimum number or percentage of pods that must remain available.
+  ## @param frontendComponent.podDisruptionBudget.maxUnavailable Maximum number or percentage of pods that can be unavailable.
+  ## Set exactly one of minAvailable or maxUnavailable when enabled.
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: ""
+    maxUnavailable: ""
 
   ## @param frontendComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -1047,6 +1067,16 @@ computeComponent:
   ## @param computeComponent.replicas Number of replicas.
   ##
   replicas: 1
+
+  ## @param computeComponent.podDisruptionBudget.enabled Enable PodDisruptionBudget for compute pods.
+  ## @param computeComponent.podDisruptionBudget.minAvailable Minimum number or percentage of pods that must remain available.
+  ## @param computeComponent.podDisruptionBudget.maxUnavailable Maximum number or percentage of pods that can be unavailable.
+  ## Set exactly one of minAvailable or maxUnavailable when enabled.
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: ""
+    maxUnavailable: ""
 
   ## @param computeComponent.resourceGroups List of resource groups for compute nodes. Each resource group is a map with
   ## at least 'name' (required, must be unique) and 'replicas' (optional). Any other fields in computeComponent can be
@@ -1215,6 +1245,16 @@ compactorComponent:
   ##
   replicas: 1
 
+  ## @param compactorComponent.podDisruptionBudget.enabled Enable PodDisruptionBudget for compactor pods.
+  ## @param compactorComponent.podDisruptionBudget.minAvailable Minimum number or percentage of pods that must remain available.
+  ## @param compactorComponent.podDisruptionBudget.maxUnavailable Maximum number or percentage of pods that can be unavailable.
+  ## Set exactly one of minAvailable or maxUnavailable when enabled.
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: ""
+    maxUnavailable: ""
+
   ## @param compactorComponent.resources Resource requests and limits.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   ## Note: Set requests and limits to the same values to ensure guaranteed QoS and avoid
@@ -1317,6 +1357,16 @@ icebergCompactorComponent:
   ## @param icebergCompactorComponent.replicas Number of replicas.
   ##
   replicas: 1
+
+  ## @param icebergCompactorComponent.podDisruptionBudget.enabled Enable PodDisruptionBudget for Iceberg compactor pods.
+  ## @param icebergCompactorComponent.podDisruptionBudget.minAvailable Minimum number or percentage of pods that must remain available.
+  ## @param icebergCompactorComponent.podDisruptionBudget.maxUnavailable Maximum number or percentage of pods that can be unavailable.
+  ## Set exactly one of minAvailable or maxUnavailable when enabled.
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: ""
+    maxUnavailable: ""
 
   ## All configurations are the same as compactorComponent.
   ## For brevity, they are not repeated here.


### PR DESCRIPTION
## Summary
- add optional per-component PodDisruptionBudget values for distributed RisingWave components
- render policy/v1 PDBs with exact-one minAvailable/maxUnavailable validation
- support compute resource group PDB inheritance and overrides

Fixes #236

## Tests
- helm unittest --strict -f tests/pdb_test.yaml charts/risingwave
- helm lint --strict --set tags.bundle=true charts/risingwave