### PR TITLE
chore: bump risingwave chart version to 0.2.53

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.52
+version: 0.2.53
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Stacked on #239.

Bumps the RisingWave chart version from 0.2.52 to 0.2.53 for the PDB support changes.
