### PR TITLE
fix(risingwave-operator): grant events.k8s.io RBAC

### DIFF
--- a/charts/risingwave-operator/Chart.yaml
+++ b/charts/risingwave-operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.38
+version: 0.1.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave-operator/templates/clusterrole.yaml
+++ b/charts/risingwave-operator/templates/clusterrole.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 rules:
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/charts/risingwave-operator/tests/clusterrole_test.yaml
+++ b/charts/risingwave-operator/tests/clusterrole_test.yaml
@@ -23,7 +23,7 @@ tests:
       path: rules
       content:
         apiGroups:
-        - ""
+        - events.k8s.io
         resources:
         - events
         verbs:


### PR DESCRIPTION
## Summary

- update the operator manager ClusterRole to create and patch Events in `events.k8s.io`
- keep the leader-election Role's core/v1 Events permission unchanged
- bump the chart version to `0.1.39`

## Rationale

The operator's controller-runtime Event recorder now writes `events.k8s.io/v1` Events after risingwavelabs/risingwave-operator#1060, but the Helm chart still granted the manager access only to core/v1 Events. As a result, reconciliation could succeed while lifecycle Event writes failed with an RBAC `forbidden` error. This aligns the manager permission with the API it uses without broadening the resource or verb set.

## Validation

- `helm lint --strict charts/risingwave-operator`
- `helm unittest --strict -f 'tests/**/*_test.yaml' charts/risingwave-operator` (70 tests passed)
- rendered the manager ClusterRole and leader-election Role with `helm template`
- `git diff --check`
