### PR TITLE
fix: probe both embedded serving ports

### DIFF
--- a/charts/risingwave/Chart.yaml
+++ b/charts/risingwave/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.56
+version: 0.2.57
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/risingwave/templates/frontend-deploy.yaml
+++ b/charts/risingwave/templates/frontend-deploy.yaml
@@ -334,8 +334,18 @@ spec:
         readinessProbe:
           initialDelaySeconds: 2
           periodSeconds: 10
+          {{- if .Values.frontendComponent.embeddedServing }}
+          exec:
+            command:
+            - /bin/sh
+            - -ec
+            - |-
+              nc -z 127.0.0.1 {{ .Values.ports.frontend.svc }}
+              nc -z 127.0.0.1 {{ .Values.ports.compute.svc }}
+          {{- else }}
           tcpSocket:
             port: svc
+          {{- end }}
         {{- end }}
       {{- if .Values.frontendComponent.additionalContainers }}
       {{- toYaml .Values.frontendComponent.additionalContainers | nindent 6 }}

--- a/charts/risingwave/templates/frontend-deploy.yaml
+++ b/charts/risingwave/templates/frontend-deploy.yaml
@@ -337,11 +337,11 @@ spec:
           {{- if .Values.frontendComponent.embeddedServing }}
           exec:
             command:
-            - /bin/sh
+            - bash
             - -ec
             - |-
-              nc -z 127.0.0.1 {{ .Values.ports.frontend.svc }}
-              nc -z 127.0.0.1 {{ .Values.ports.compute.svc }}
+              </dev/tcp/127.0.0.1/{{ .Values.ports.frontend.svc }}
+              </dev/tcp/127.0.0.1/{{ .Values.ports.compute.svc }}
           {{- else }}
           tcpSocket:
             port: svc

--- a/charts/risingwave/tests/frontend_embedded_serving_test.yaml
+++ b/charts/risingwave/tests/frontend_embedded_serving_test.yaml
@@ -17,6 +17,42 @@ tests:
       value:
       - /risingwave/bin/risingwave
       - standalone
+- it: readiness probe should check both frontend and compute listeners
+  template: frontend-deploy.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+      value: 2
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+      value: 10
+  - notExists:
+      path: spec.template.spec.containers[0].readinessProbe.tcpSocket
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe.exec.command
+      value:
+      - /bin/sh
+      - -ec
+      - |-
+        nc -z 127.0.0.1 4567
+        nc -z 127.0.0.1 5688
+- it: standard frontend readiness probe should remain unchanged
+  template: frontend-deploy.yaml
+  set:
+    frontendComponent:
+      embeddedServing: false
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+      value: 2
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+      value: 10
+  - notExists:
+      path: spec.template.spec.containers[0].readinessProbe.exec
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+      value: svc
 - it: should have pre-stop lifecycle hook when auto deregistration is enabled
   template: frontend-deploy.yaml
   set:

--- a/charts/risingwave/tests/frontend_embedded_serving_test.yaml
+++ b/charts/risingwave/tests/frontend_embedded_serving_test.yaml
@@ -31,11 +31,11 @@ tests:
   - equal:
       path: spec.template.spec.containers[0].readinessProbe.exec.command
       value:
-      - /bin/sh
+      - bash
       - -ec
       - |-
-        nc -z 127.0.0.1 4567
-        nc -z 127.0.0.1 5688
+        </dev/tcp/127.0.0.1/4567
+        </dev/tcp/127.0.0.1/5688
 - it: standard frontend readiness probe should remain unchanged
   template: frontend-deploy.yaml
   set:


### PR DESCRIPTION
## Summary

- require embedded-serving frontend pods to pass readiness checks on both the frontend and compute listeners
- preserve the existing readiness probe and timing for standard frontend pods
- add unit coverage for both frontend modes

## Rationale

In embedded serving mode, the frontend container runs both a frontend node and a serving compute node. The existing probe checked only the frontend listener, so Kubernetes could mark the pod ready before the embedded compute listener was accepting connections. Requiring both ports prevents premature readiness and ensures the complete embedded-serving workload is available before the pod receives traffic.

## Validation

- `helm unittest --strict -f tests/frontend_embedded_serving_test.yaml charts/risingwave`
- `helm lint --strict --set tags.bundle=true charts/risingwave`
- rendered the frontend deployment in both embedded-serving and standard modes
